### PR TITLE
allow setter methods to have a non-void return type

### DIFF
--- a/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/rebind/property/PropertyParser.java
+++ b/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/rebind/property/PropertyParser.java
@@ -135,29 +135,24 @@ public final class PropertyParser {
                 continue;
             }
 
-            JType returnType = method.getReturnType();
-            if ( null != returnType.isPrimitive() && JPrimitiveType.VOID.equals( returnType.isPrimitive() ) ) {
-                // might be a setter
-                if ( method.getParameters().length == 1 || (method.getParameters().length == 2 && method.isAnnotationPresent( JsonAnySetter.class )) ) {
-                    String fieldName = extractFieldNameFromGetterSetterMethodName( method.getName() );
-                    PropertyAccessorsBuilder property = propertiesMap.get( fieldName );
-                    if ( null == property ) {
-                        property = new PropertyAccessorsBuilder( fieldName );
-                        propertiesMap.put( fieldName, property );
-                    }
-                    property.addSetter( method, mixin );
-                }
-            } else {
+            if ( method.getParameters().length == 0 ) {
                 // might be a getter
-                if ( method.getParameters().length == 0 ) {
-                    String fieldName = extractFieldNameFromGetterSetterMethodName( method.getName() );
-                    PropertyAccessorsBuilder property = propertiesMap.get( fieldName );
-                    if ( null == property ) {
-                        property = new PropertyAccessorsBuilder( fieldName );
-                        propertiesMap.put( fieldName, property );
-                    }
-                    property.addGetter( method, mixin );
+                String fieldName = extractFieldNameFromGetterSetterMethodName( method.getName() );
+                PropertyAccessorsBuilder property = propertiesMap.get( fieldName );
+                if ( null == property ) {
+                    property = new PropertyAccessorsBuilder( fieldName );
+                    propertiesMap.put( fieldName, property );
                 }
+                property.addGetter( method, mixin );
+            } else if ( method.getParameters().length == 1 || (method.getParameters().length == 2 && method.isAnnotationPresent( JsonAnySetter.class )) ) {
+                // might be a setter
+                String fieldName = extractFieldNameFromGetterSetterMethodName( method.getName() );
+                PropertyAccessorsBuilder property = propertiesMap.get( fieldName );
+                if ( null == property ) {
+                    property = new PropertyAccessorsBuilder( fieldName );
+                    propertiesMap.put( fieldName, property );
+                }
+                property.addSetter( method, mixin );
             }
         }
     }


### PR DESCRIPTION
v0.9.0 of gwt-jackson does not automatically recognise setter methods that have a non-void return type, while, the main jackson v2.5.x does not have this restriction. This change brings the behaviour of gwt-jackson in line with behaviour of the FasterXML Jackson. Some of my setter return "this" to allow for method chaining. 

Please let me know if there is some reason for the current restriction. Thanks for your work with this gwt implementation! 