### PR TITLE
Make adjust dates to context time zone configurable

### DIFF
--- a/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/JsonDeserializationContext.java
+++ b/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/JsonDeserializationContext.java
@@ -174,7 +174,7 @@ public class JsonDeserializationContext extends JsonMappingContext {
          *
          */
         public Builder adjustDatesToContextTimeZone(boolean adjustDatesToContextTimeZone) {
-            this.adjustDatesToContextTimeZone = true;
+            this.adjustDatesToContextTimeZone = adjustDatesToContextTimeZone;
             return this;
         }
 

--- a/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/JsonDeserializationContext.java
+++ b/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/JsonDeserializationContext.java
@@ -63,11 +63,12 @@ public class JsonDeserializationContext extends JsonMappingContext {
 
         protected boolean readUnknownEnumValuesAsNull = false;
 
+        protected boolean adjustDatesToContextTimeZone = true;
+
         /**
          * @deprecated Use {@link JsonDeserializationContext#builder()} instead. This constructor will be made protected in v1.0.
          */
         @Deprecated
-
         public Builder() { }
 
         /**
@@ -162,10 +163,24 @@ public class JsonDeserializationContext extends JsonMappingContext {
             this.readUnknownEnumValuesAsNull = readUnknownEnumValuesAsNull;
             return this;
         }
+        
+        /**
+         * Feature that specifies whether context provided {@link java.util.TimeZone}
+         * should be used to adjust Date/Time values on deserialization,
+         * even if value itself contains timezone information.
+         * If enabled, contextual <code>TimeZone</code> will essentially override any other
+         * TimeZone information; if disabled, it will only be used if value itself does not
+         * contain any TimeZone information.
+         *
+         */
+        public Builder adjustDatesToContextTimeZone(boolean adjustDatesToContextTimeZone) {
+            this.adjustDatesToContextTimeZone = true;
+            return this;
+        }
 
         public final JsonDeserializationContext build() {
             return new JsonDeserializationContext( failOnUnknownProperties, unwrapRootValue, acceptSingleValueAsArray, wrapExceptions,
-                    useSafeEval, readUnknownEnumValuesAsNull );
+                    useSafeEval, readUnknownEnumValuesAsNull, adjustDatesToContextTimeZone );
         }
     }
 
@@ -198,14 +213,18 @@ public class JsonDeserializationContext extends JsonMappingContext {
 
     private final boolean readUnknownEnumValuesAsNull;
 
+    private final boolean adjustDatesToContextTimeZone;
+
     private JsonDeserializationContext( boolean failOnUnknownProperties, boolean unwrapRootValue, boolean acceptSingleValueAsArray,
-                                        boolean wrapExceptions, boolean useSafeEval, boolean readUnknownEnumValuesAsNull ) {
+                                        boolean wrapExceptions, boolean useSafeEval, boolean readUnknownEnumValuesAsNull,
+                                        boolean adjustDatesToContextTimeZone ) {
         this.failOnUnknownProperties = failOnUnknownProperties;
         this.unwrapRootValue = unwrapRootValue;
         this.acceptSingleValueAsArray = acceptSingleValueAsArray;
         this.wrapExceptions = wrapExceptions;
         this.useSafeEval = useSafeEval;
         this.readUnknownEnumValuesAsNull = readUnknownEnumValuesAsNull;
+        this.adjustDatesToContextTimeZone = adjustDatesToContextTimeZone;
     }
 
     @Override
@@ -246,6 +265,13 @@ public class JsonDeserializationContext extends JsonMappingContext {
      */
     public boolean isReadUnknownEnumValuesAsNull() {
         return readUnknownEnumValuesAsNull;
+    }
+
+    /**
+     * @see Builder#adjustDatesToContextTimeZone(boolean)
+     */
+    public boolean isAdjustDatesToContextTimeZone() {
+        return adjustDatesToContextTimeZone;
     }
 
     public JsonReader newJsonReader( String input ) {

--- a/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/deser/BaseDateJsonDeserializer.java
+++ b/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/deser/BaseDateJsonDeserializer.java
@@ -61,14 +61,14 @@ public abstract class BaseDateJsonDeserializer<D extends Date> extends JsonDeser
         }
     }
 
-    private static final String SQL_DATE_FORMAT = "yyyy-MM-dd";
-
     /**
      * Default implementation of {@link BaseDateJsonDeserializer} for {@link java.sql.Date}
      */
     public static final class SqlDateJsonDeserializer extends BaseDateJsonDeserializer<java.sql.Date> {
 
         private static final SqlDateJsonDeserializer INSTANCE = new SqlDateJsonDeserializer();
+
+        private static final String SQL_DATE_FORMAT = "yyyy-MM-dd";
 
         /**
          * @return an instance of {@link SqlDateJsonDeserializer}

--- a/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/deser/BaseDateJsonDeserializer.java
+++ b/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/deser/BaseDateJsonDeserializer.java
@@ -26,7 +26,6 @@ import com.github.nmorel.gwtjackson.client.JsonDeserializerParameters;
 import com.github.nmorel.gwtjackson.client.stream.JsonReader;
 import com.github.nmorel.gwtjackson.client.stream.JsonToken;
 import com.github.nmorel.gwtjackson.client.utils.DateFormat;
-import com.google.gwt.i18n.client.DateTimeFormat;
 
 /**
  * Base implementation of {@link JsonDeserializer} for dates.
@@ -57,10 +56,12 @@ public abstract class BaseDateJsonDeserializer<D extends Date> extends JsonDeser
         }
 
         @Override
-        protected Date deserializeString( String date, JsonDeserializerParameters params ) {
-            return DateFormat.parse( params.getPattern(), date );
+        protected Date deserializeString( String date, JsonDeserializationContext ctx, JsonDeserializerParameters params ) {
+            return DateFormat.parse(ctx.isAdjustDatesToContextTimeZone(), params.getPattern(), date );
         }
     }
+
+    private static final String SQL_DATE_FORMAT = "yyyy-MM-dd";
 
     /**
      * Default implementation of {@link BaseDateJsonDeserializer} for {@link java.sql.Date}
@@ -84,9 +85,8 @@ public abstract class BaseDateJsonDeserializer<D extends Date> extends JsonDeser
         }
 
         @Override
-        protected java.sql.Date deserializeString( String date, JsonDeserializerParameters params ) {
-            Date d = SQL_DATE_FORMAT.parse( date + " +0000" );
-            return new java.sql.Date( d.getTime() );
+        protected java.sql.Date deserializeString( String date, JsonDeserializationContext ctx, JsonDeserializerParameters params ) {
+            return new java.sql.Date( DateFormat.parse(ctx.isAdjustDatesToContextTimeZone(), SQL_DATE_FORMAT, date).getTime() );
         }
     }
 
@@ -112,7 +112,7 @@ public abstract class BaseDateJsonDeserializer<D extends Date> extends JsonDeser
         }
 
         @Override
-        protected Time deserializeString( String date, JsonDeserializerParameters params ) {
+        protected Time deserializeString( String date, JsonDeserializationContext ctx, JsonDeserializerParameters params ) {
             return Time.valueOf( date );
         }
     }
@@ -139,23 +139,21 @@ public abstract class BaseDateJsonDeserializer<D extends Date> extends JsonDeser
         }
 
         @Override
-        protected Timestamp deserializeString( String date, JsonDeserializerParameters params ) {
-            return new Timestamp( DateFormat.parse( params.getPattern(), date ).getTime() );
+        protected Timestamp deserializeString( String date, JsonDeserializationContext ctx, JsonDeserializerParameters params ) {
+            return new Timestamp( DateFormat.parse(ctx.isAdjustDatesToContextTimeZone(), params.getPattern(), date ).getTime() );
         }
     }
-
-    private static final DateTimeFormat SQL_DATE_FORMAT = DateTimeFormat.getFormat( "yyyy-MM-dd Z" );
 
     @Override
     public D doDeserialize( JsonReader reader, JsonDeserializationContext ctx, JsonDeserializerParameters params ) {
         if ( params.getShape().isNumeric() || JsonToken.NUMBER.equals( reader.peek() ) ) {
             return deserializeNumber( reader.nextLong(), params );
         } else {
-            return deserializeString( reader.nextString(), params );
+            return deserializeString( reader.nextString(), ctx, params );
         }
     }
 
     protected abstract D deserializeNumber( long millis, JsonDeserializerParameters params );
 
-    protected abstract D deserializeString( String date, JsonDeserializerParameters params );
+    protected abstract D deserializeString( String date, JsonDeserializationContext ctx, JsonDeserializerParameters params );
 }

--- a/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/deser/BaseDateJsonDeserializer.java
+++ b/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/deser/BaseDateJsonDeserializer.java
@@ -57,7 +57,7 @@ public abstract class BaseDateJsonDeserializer<D extends Date> extends JsonDeser
 
         @Override
         protected Date deserializeString( String date, JsonDeserializationContext ctx, JsonDeserializerParameters params ) {
-            return DateFormat.parse(ctx.isAdjustDatesToContextTimeZone(), params.getPattern(), date );
+            return DateFormat.parse(ctx.isAdjustDatesToContextTimeZone(), params.getPattern(), null, date );
         }
     }
 
@@ -86,7 +86,7 @@ public abstract class BaseDateJsonDeserializer<D extends Date> extends JsonDeser
 
         @Override
         protected java.sql.Date deserializeString( String date, JsonDeserializationContext ctx, JsonDeserializerParameters params ) {
-            return new java.sql.Date( DateFormat.parse(ctx.isAdjustDatesToContextTimeZone(), SQL_DATE_FORMAT, date).getTime() );
+            return new java.sql.Date( DateFormat.parse(ctx.isAdjustDatesToContextTimeZone(), SQL_DATE_FORMAT, false, date).getTime() );
         }
     }
 
@@ -140,7 +140,7 @@ public abstract class BaseDateJsonDeserializer<D extends Date> extends JsonDeser
 
         @Override
         protected Timestamp deserializeString( String date, JsonDeserializationContext ctx, JsonDeserializerParameters params ) {
-            return new Timestamp( DateFormat.parse(ctx.isAdjustDatesToContextTimeZone(), params.getPattern(), date ).getTime() );
+            return new Timestamp( DateFormat.parse(ctx.isAdjustDatesToContextTimeZone(), params.getPattern(), null, date ).getTime() );
         }
     }
 

--- a/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/utils/DateFormat.java
+++ b/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/utils/DateFormat.java
@@ -184,7 +184,7 @@ public final class DateFormat {
         } else {
             DateParser parser = CACHE_PARSERS.get( pattern );
             if ( null == parser ) {
-                if ( hasTz( pattern ) || !adjustDatesToContextTimeZone) {
+                if ( !adjustDatesToContextTimeZone || hasTz( pattern ) ) {
                     parser = new DateParser( pattern );
                 } else {
                     // the pattern does not have a timezone, we use the UTC timezone as reference

--- a/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/utils/DateFormat.java
+++ b/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/utils/DateFormat.java
@@ -178,13 +178,13 @@ public final class DateFormat {
      *
      * @return the parsed date
      */
-    public static Date parse( String pattern, String date ) {
+    public static Date parse( boolean adjustDatesToContextTimeZone, String pattern, String date ) {
         if ( null == pattern ) {
             return parse( DateFormat.DATE_FORMAT_STR_ISO8601, date );
         } else {
             DateParser parser = CACHE_PARSERS.get( pattern );
             if ( null == parser ) {
-                if ( hasTz( pattern ) ) {
+                if ( hasTz( pattern ) || !adjustDatesToContextTimeZone) {
                     parser = new DateParser( pattern );
                 } else {
                     // the pattern does not have a timezone, we use the UTC timezone as reference
@@ -195,6 +195,7 @@ public final class DateFormat {
             return parser.parse( date );
         }
     }
+
 
     /**
      * Find if a pattern contains informations about the timezone.

--- a/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/utils/DateFormat.java
+++ b/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/utils/DateFormat.java
@@ -184,7 +184,8 @@ public final class DateFormat {
         if ( null == pattern ) {
             return parse( DateFormat.DATE_FORMAT_STR_ISO8601, date );
         } else {
-            DateParser parser = CACHE_PARSERS.get( pattern );
+            String patternCacheKey = pattern + adjustDatesToContextTimeZone;
+            DateParser parser = CACHE_PARSERS.get( patternCacheKey );
             if ( null == parser ) {
                 boolean patternNeedTz = patternHasTz == null ?
                     !adjustDatesToContextTimeZone || hasTz(pattern) :
@@ -195,7 +196,7 @@ public final class DateFormat {
                     // the pattern does not have a timezone, we use the UTC timezone as reference
                     parser = new DateParserNoTz( pattern );
                 }
-                CACHE_PARSERS.put( pattern, parser );
+                CACHE_PARSERS.put( patternCacheKey, parser );
             }
             return parser.parse( date );
         }

--- a/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/utils/DateFormat.java
+++ b/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/utils/DateFormat.java
@@ -173,18 +173,23 @@ public final class DateFormat {
     /**
      * Parse a date using the pattern given in parameter or {@link #DATE_FORMAT_STR_ISO8601} and the browser timezone.
      *
+     * @param adjustDatesToContextTimeZone wheter the date needs to adjusted to current timezone.
      * @param pattern pattern to use. If null, {@link #DATE_FORMAT_STR_ISO8601} will be used.
+     * @param patternHasTz whether the pattern includes timezone information. when null the pattern will be parsed to search it.
      * @param date date to parse
      *
      * @return the parsed date
      */
-    public static Date parse( boolean adjustDatesToContextTimeZone, String pattern, String date ) {
+    public static Date parse( boolean adjustDatesToContextTimeZone, String pattern, Boolean patternHasTz, String date ) {
         if ( null == pattern ) {
             return parse( DateFormat.DATE_FORMAT_STR_ISO8601, date );
         } else {
             DateParser parser = CACHE_PARSERS.get( pattern );
             if ( null == parser ) {
-                if ( !adjustDatesToContextTimeZone || hasTz( pattern ) ) {
+                boolean patternNeedTz = patternHasTz == null ?
+                    !adjustDatesToContextTimeZone || hasTz(pattern) :
+                    !adjustDatesToContextTimeZone || patternHasTz.booleanValue();
+                if ( patternNeedTz ) {
                     parser = new DateParser( pattern );
                 } else {
                     // the pattern does not have a timezone, we use the UTC timezone as reference
@@ -195,7 +200,6 @@ public final class DateFormat {
             return parser.parse( date );
         }
     }
-
 
     /**
      * Find if a pattern contains informations about the timezone.

--- a/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/client/options/DateOptionsGwtTest.java
+++ b/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/client/options/DateOptionsGwtTest.java
@@ -17,6 +17,7 @@
 package com.github.nmorel.gwtjackson.client.options;
 
 import com.github.nmorel.gwtjackson.client.GwtJacksonTestCase;
+import com.github.nmorel.gwtjackson.client.JsonDeserializationContext;
 import com.github.nmorel.gwtjackson.client.JsonSerializationContext;
 import com.github.nmorel.gwtjackson.client.ObjectMapper;
 import com.github.nmorel.gwtjackson.shared.options.DateOptionsTester;
@@ -51,5 +52,10 @@ public class DateOptionsGwtTest extends GwtJacksonTestCase {
 
     public void testDeserializeDatesNotAsTimestamps() {
         tester.testDeserializeDatesNotAsTimestamps( createReader( BeanWithDatesMapper.INSTANCE ) );
+    }
+
+    public void testDeserializeDatesNotAsTimestampsAndNotAdjustTimeZone() {
+        tester.testDeserializeDatesNotAsTimestampsAndNotAdjustTimeZone(createReader( BeanWithDatesMapper.INSTANCE, JsonDeserializationContext.builder()
+            .adjustDatesToContextTimeZone(false).build() ) );
     }
 }

--- a/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/shared/options/DateOptionsTester.java
+++ b/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/shared/options/DateOptionsTester.java
@@ -22,9 +22,12 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import com.github.nmorel.gwtjackson.shared.AbstractTester;
 import com.github.nmorel.gwtjackson.shared.ObjectReaderTester;
 import com.github.nmorel.gwtjackson.shared.ObjectWriterTester;
+import com.google.gwt.i18n.client.DateTimeFormat;
 
 /**
  * @author Nicolas Morel
@@ -34,6 +37,9 @@ public final class DateOptionsTester extends AbstractTester {
     public static class BeanWithDates {
 
         public Date date;
+
+        @JsonFormat( shape = Shape.STRING, pattern = "/yyyy/MM/dd/" )
+        public Date onlyDate;
 
         public java.sql.Date sqlDate;
 
@@ -58,6 +64,7 @@ public final class DateOptionsTester extends AbstractTester {
     public void testSerializeDatesAsTimestamps( ObjectWriterTester<BeanWithDates> writer ) {
         BeanWithDates bean = new BeanWithDates();
         bean.date = new Date( 1345304756540l );
+        bean.onlyDate = new Date( 1345304756540l );
         bean.sqlDate = new java.sql.Date( 1345304756541l );
         bean.sqlTime = new Time( 1345304756542l );
         bean.sqlTimestamp = new Timestamp( 1345304756543l );
@@ -80,6 +87,7 @@ public final class DateOptionsTester extends AbstractTester {
 
         String expected = "{" +
                 "\"date\":1345304756540," +
+                "\"onlyDate\":1345304756540," +
                 "\"sqlDate\":\"" + bean.sqlDate.toString() + "\"," +
                 "\"sqlTime\":\"" + bean.sqlTime.toString() + "\"," +
                 "\"sqlTimestamp\":1345304756543," +
@@ -96,6 +104,7 @@ public final class DateOptionsTester extends AbstractTester {
 
         String input = "{" +
                 "\"date\":1345304756540," +
+                "\"onlyDate\":1345304756540," +
                 "\"sqlDate\":\"2012-08-18\"," +
                 "\"sqlTime\":\"15:45:56\"," +
                 "\"sqlTimestamp\":1345304756543," +
@@ -104,6 +113,7 @@ public final class DateOptionsTester extends AbstractTester {
 
         BeanWithDates bean = reader.read( input );
         assertEquals( new Date( 1345304756540l ), bean.date );
+        assertEquals( new Date( 1345304756540l ), bean.onlyDate );
         assertEquals( getUTCTime( 2012, 8, 18, 0, 0, 0, 0 ), bean.sqlDate.getTime() );
         assertEquals( new Time( 15, 45, 56 ), bean.sqlTime );
         assertEquals( new java.sql.Timestamp( 1345304756543l ), bean.sqlTimestamp );
@@ -118,6 +128,7 @@ public final class DateOptionsTester extends AbstractTester {
     public void testSerializeDatesNotAsTimestamps( ObjectWriterTester<BeanWithDates> writer ) {
         BeanWithDates bean = new BeanWithDates();
         bean.date = getUTCDate( 2012, 8, 18, 15, 45, 56, 540 );
+        bean.onlyDate = getUTCDate( 2012, 8, 18, 15, 45, 56, 540 );
         bean.sqlDate = new java.sql.Date( getUTCTime( 2012, 8, 18, 15, 45, 56, 541 ) );
         bean.sqlTime = new java.sql.Time( getUTCTime( 2012, 8, 18, 15, 45, 56, 542 ) );
         bean.sqlTimestamp = new java.sql.Timestamp( getUTCTime( 2012, 8, 18, 15, 45, 56, 543 ) );
@@ -140,6 +151,7 @@ public final class DateOptionsTester extends AbstractTester {
 
         String expected = "{" +
                 "\"date\":\"2012-08-18T15:45:56.540+0000\"," +
+                "\"onlyDate\":\"/2012/08/18/\"," +
                 "\"sqlDate\":\"" + bean.sqlDate.toString() + "\"," +
                 "\"sqlTime\":\"" + bean.sqlTime.toString() + "\"," +
                 "\"sqlTimestamp\":\"2012-08-18T15:45:56.543+0000\"," +
@@ -153,9 +165,9 @@ public final class DateOptionsTester extends AbstractTester {
     }
 
     public void testDeserializeDatesNotAsTimestamps( ObjectReaderTester<BeanWithDates> reader ) {
-
         String input = "{" +
                 "\"date\":\"2012-08-18T15:45:56.540+0000\"," +
+                "\"onlyDate\":\"/2012/08/18/\"," +
                 "\"sqlDate\":\"2012-08-18\"," +
                 "\"sqlTime\":\"15:45:56\"," +
                 "\"sqlTimestamp\":\"2012-08-18T15:45:56.543+0000\"," +
@@ -164,7 +176,33 @@ public final class DateOptionsTester extends AbstractTester {
 
         BeanWithDates bean = reader.read( input );
         assertEquals( new Date( 1345304756540l ), bean.date );
+        assertEquals( DateTimeFormat.getFormat("yyyy/MM/dd Z").parse("2012/08/18 +0000"), bean.onlyDate );
         assertEquals( getUTCTime( 2012, 8, 18, 0, 0, 0, 0 ), bean.sqlDate.getTime() );
+        assertEquals( new Time( 15, 45, 56 ), bean.sqlTime );
+        assertEquals( new java.sql.Timestamp( 1345304756543l ), bean.sqlTimestamp );
+
+        Map<Date, String> mapDate = new HashMap<Date, String>();
+        mapDate.put( new Date( 1345304756544l ), "java.util.Date" );
+        assertEquals( mapDate, bean.mapDate );
+
+        // Jackson is not able to deserialize java.sql.* types as string so we don't bother testing it
+    }
+
+    public void testDeserializeDatesNotAsTimestampsAndNotAdjustTimeZone( ObjectReaderTester<BeanWithDates> reader ) {
+        String input = "{" +
+            "\"date\":\"2012-08-18T15:45:56.540+0000\"," +
+            "\"onlyDate\":\"/2012/08/18/\"," +
+            "\"sqlDate\":\"2012-08-18\"," +
+            "\"sqlTime\":\"15:45:56\"," +
+            "\"sqlTimestamp\":\"2012-08-18T15:45:56.543+0000\"," +
+            "\"mapDate\":{\"2012-08-18T15:45:56.544+0000\":\"java.util.Date\"}" +
+            "}";
+
+        BeanWithDates bean = reader.read( input );
+        assertEquals( new Date( 1345304756540l ), bean.date );
+        Date dateUsingDefaultTimeZone = DateTimeFormat.getFormat("yyyy/MM/dd").parse("2012/08/18");
+        assertEquals( dateUsingDefaultTimeZone, bean.onlyDate );
+        assertEquals( dateUsingDefaultTimeZone, bean.sqlDate );
         assertEquals( new Time( 15, 45, 56 ), bean.sqlTime );
         assertEquals( new java.sql.Timestamp( 1345304756543l ), bean.sqlTimestamp );
 

--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,32 @@
             </dependency>
           </dependencies>
         </plugin>
+
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>gwt-maven-plugin</artifactId>
+                    <versionRange>[2.7.0,)</versionRange>
+                    <goals>
+                      <goal>resources</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Currently I need to interpret some dates without the timezone. for example a person fills a timesheet for a day, i.e. 11/30/2011, that is transmitted in a json like: 
```javascript
{"id": 42, "date": "2011-11-30"}
```
when my timezone is GMT-3 it's converted to 2011-11-29 21:00:00 
so I added a config param to avoid assuming that all dates without TZ information are GMT
 
