### PR TITLE
Issue #58 - added readUnknownEnumValuesAsNull option to JsonDeserializationContext

### DIFF
--- a/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/JsonDeserializationContext.java
+++ b/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/JsonDeserializationContext.java
@@ -61,10 +61,13 @@ public class JsonDeserializationContext extends JsonMappingContext {
 
         protected boolean useSafeEval = true;
 
+        protected boolean readUnknownEnumValuesAsNull = false;
+
         /**
          * @deprecated Use {@link JsonDeserializationContext#builder()} instead. This constructor will be made protected in v1.0.
          */
         @Deprecated
+
         public Builder() { }
 
         /**
@@ -151,9 +154,18 @@ public class JsonDeserializationContext extends JsonMappingContext {
             return this;
         }
 
+        /**
+         * Feature that determines whether gwt-jackson should return null for unknown enum values.
+         * Default is false which will throw {@link IllegalArgumentException} when unknown enum value is found.
+         */
+        public Builder readUnknownEnumValuesAsNull( boolean readUnknownEnumValuesAsNull ) {
+            this.readUnknownEnumValuesAsNull = readUnknownEnumValuesAsNull;
+            return this;
+        }
+
         public final JsonDeserializationContext build() {
             return new JsonDeserializationContext( failOnUnknownProperties, unwrapRootValue, acceptSingleValueAsArray, wrapExceptions,
-                    useSafeEval );
+                    useSafeEval, readUnknownEnumValuesAsNull );
         }
     }
 
@@ -184,13 +196,16 @@ public class JsonDeserializationContext extends JsonMappingContext {
 
     private final boolean useSafeEval;
 
+    private final boolean readUnknownEnumValuesAsNull;
+
     private JsonDeserializationContext( boolean failOnUnknownProperties, boolean unwrapRootValue, boolean acceptSingleValueAsArray,
-                                        boolean wrapExceptions, boolean useSafeEval ) {
+                                        boolean wrapExceptions, boolean useSafeEval, boolean readUnknownEnumValuesAsNull ) {
         this.failOnUnknownProperties = failOnUnknownProperties;
         this.unwrapRootValue = unwrapRootValue;
         this.acceptSingleValueAsArray = acceptSingleValueAsArray;
         this.wrapExceptions = wrapExceptions;
         this.useSafeEval = useSafeEval;
+        this.readUnknownEnumValuesAsNull = readUnknownEnumValuesAsNull;
     }
 
     @Override
@@ -224,6 +239,13 @@ public class JsonDeserializationContext extends JsonMappingContext {
      */
     public boolean isUseSafeEval() {
         return useSafeEval;
+    }
+
+    /**
+     * @see Builder#readUnknownEnumValuesAsNull(boolean)
+     */
+    public boolean isReadUnknownEnumValuesAsNull() {
+        return readUnknownEnumValuesAsNull;
     }
 
     public JsonReader newJsonReader( String input ) {

--- a/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/deser/EnumJsonDeserializer.java
+++ b/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/deser/EnumJsonDeserializer.java
@@ -54,7 +54,14 @@ public class EnumJsonDeserializer<E extends Enum<E>> extends JsonDeserializer<E>
 
     @Override
     public E doDeserialize( JsonReader reader, JsonDeserializationContext ctx, JsonDeserializerParameters params ) {
-        return Enum.valueOf( enumClass, reader.nextString() );
+        try {
+            return Enum.valueOf( enumClass, reader.nextString() );
+        } catch ( IllegalArgumentException ex ) {
+            if ( ctx.isReadUnknownEnumValuesAsNull() ) {
+                return null;
+            }
+            throw ex;
+        }
     }
 
     public Class<E> getEnumClass() {

--- a/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/deser/map/key/EnumKeyDeserializer.java
+++ b/gwt-jackson/src/main/java/com/github/nmorel/gwtjackson/client/deser/map/key/EnumKeyDeserializer.java
@@ -51,7 +51,14 @@ public final class EnumKeyDeserializer<E extends Enum<E>> extends KeyDeserialize
 
     @Override
     protected E doDeserialize( String key, JsonDeserializationContext ctx ) {
-        return Enum.valueOf( enumClass, key );
+        try {
+            return Enum.valueOf( enumClass, key );
+        } catch ( IllegalArgumentException ex ) {
+            if ( ctx.isReadUnknownEnumValuesAsNull() ) {
+                return null;
+            }
+            throw ex;
+        }
     }
 
     public Class<E> getEnumClass() {

--- a/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/client/deser/AbstractJsonDeserializerTest.java
+++ b/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/client/deser/AbstractJsonDeserializerTest.java
@@ -18,7 +18,6 @@ package com.github.nmorel.gwtjackson.client.deser;
 
 import com.github.nmorel.gwtjackson.client.GwtJacksonTestCase;
 import com.github.nmorel.gwtjackson.client.JsonDeserializationContext;
-import com.github.nmorel.gwtjackson.client.JsonDeserializationContext.Builder;
 import com.github.nmorel.gwtjackson.client.JsonDeserializer;
 import com.github.nmorel.gwtjackson.client.stream.JsonReader;
 
@@ -35,12 +34,20 @@ public abstract class AbstractJsonDeserializerTest<T> extends GwtJacksonTestCase
 
     protected T deserialize( String value ) {
         JsonDeserializationContext ctx = JsonDeserializationContext.builder().build();
+        return deserialize( ctx, value );
+    }
+
+    protected T deserialize( JsonDeserializationContext ctx, String value ) {
         JsonReader reader = ctx.newJsonReader( value );
         return createDeserializer().deserialize( reader, ctx );
     }
 
     protected void assertDeserialization( T expected, String value ) {
         assertEquals( expected, deserialize( value ) );
+    }
+
+    protected void assertDeserialization( JsonDeserializationContext ctx, T expected, String value ) {
+        assertEquals( expected, deserialize( ctx, value ) );
     }
 
     public abstract void testDeserializeValue();

--- a/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/client/deser/EnumJsonDeserializerTest.java
+++ b/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/client/deser/EnumJsonDeserializerTest.java
@@ -16,6 +16,7 @@
 
 package com.github.nmorel.gwtjackson.client.deser;
 
+import com.github.nmorel.gwtjackson.client.JsonDeserializationContext;
 import com.github.nmorel.gwtjackson.client.JsonDeserializer;
 import com.github.nmorel.gwtjackson.client.deser.EnumJsonDeserializerTest.EnumTest;
 
@@ -39,5 +40,11 @@ public class EnumJsonDeserializerTest extends AbstractJsonDeserializerTest<EnumT
         assertDeserialization( EnumTest.TWO, "\"TWO\"" );
         assertDeserialization( EnumTest.THREE, "\"THREE\"" );
         assertDeserialization( EnumTest.FOUR, "\"FOUR\"" );
+        try {
+            assertDeserialization( null, "\"UNKNOWN\"" );
+            fail( "IllegalArgumentException should be thrown!" );
+        } catch ( IllegalArgumentException ex ) {
+        }
+        assertDeserialization( JsonDeserializationContext.builder().readUnknownEnumValuesAsNull( true ).build(), null, "\"UNKNOWN\"" );
     }
 }

--- a/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/client/deser/map/key/AbstractKeyDeserializerTest.java
+++ b/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/client/deser/map/key/AbstractKeyDeserializerTest.java
@@ -18,7 +18,6 @@ package com.github.nmorel.gwtjackson.client.deser.map.key;
 
 import com.github.nmorel.gwtjackson.client.GwtJacksonTestCase;
 import com.github.nmorel.gwtjackson.client.JsonDeserializationContext;
-import com.github.nmorel.gwtjackson.client.JsonDeserializationContext.Builder;
 
 /**
  * @author Nicolas Morel
@@ -33,11 +32,19 @@ public abstract class AbstractKeyDeserializerTest<T> extends GwtJacksonTestCase 
 
     protected T deserialize( String value ) {
         JsonDeserializationContext ctx = JsonDeserializationContext.builder().build();
+        return deserialize( ctx, value );
+    }
+
+    protected T deserialize( JsonDeserializationContext ctx, String value ) {
         return createDeserializer().deserialize( value, ctx );
     }
 
     protected void assertDeserialization( T expected, String value ) {
         assertEquals( expected, deserialize( value ) );
+    }
+
+    protected void assertDeserialization( JsonDeserializationContext ctx, T expected, String value ) {
+        assertEquals( expected, deserialize( ctx, value ) );
     }
 
     public abstract void testDeserializeValue();

--- a/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/client/deser/map/key/EnumKeyDeserializerTest.java
+++ b/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/client/deser/map/key/EnumKeyDeserializerTest.java
@@ -16,6 +16,7 @@
 
 package com.github.nmorel.gwtjackson.client.deser.map.key;
 
+import com.github.nmorel.gwtjackson.client.JsonDeserializationContext;
 import com.github.nmorel.gwtjackson.client.deser.map.key.EnumKeyDeserializerTest.EnumTest;
 
 /**
@@ -38,5 +39,11 @@ public class EnumKeyDeserializerTest extends AbstractKeyDeserializerTest<EnumTes
         assertDeserialization( EnumTest.TWO, "TWO" );
         assertDeserialization( EnumTest.THREE, "THREE" );
         assertDeserialization( EnumTest.FOUR, "FOUR" );
+        try {
+            assertDeserialization( null, "UNKNOWN" );
+            fail( "IllegalArgumentException should be thrown!" );
+        } catch ( IllegalArgumentException ex ) {
+        }
+        assertDeserialization( JsonDeserializationContext.builder().readUnknownEnumValuesAsNull( true ).build(), null, "UNKNOWN" );
     }
 }


### PR DESCRIPTION
Implemented readUnknownEnumValuesAsNull and added appropriate tests.

I may add the ability for a custom enum deserializer in the future; will create a new pull request if so.