### PR TITLE
Shows failure to properly deserialize back references

### DIFF
--- a/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/client/GwtJacksonTestSuite.java
+++ b/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/client/GwtJacksonTestSuite.java
@@ -25,6 +25,7 @@ import com.github.nmorel.gwtjackson.client.advanced.ObjectGwtTest;
 import com.github.nmorel.gwtjackson.client.advanced.PrivateAccessGwtTest;
 import com.github.nmorel.gwtjackson.client.advanced.ProxyAndAnonymousClassSerializationGwtTest;
 import com.github.nmorel.gwtjackson.client.advanced.WildcardGwtTest;
+import com.github.nmorel.gwtjackson.client.advanced.identity.ObjectIdBackReferenceGwtTest;
 import com.github.nmorel.gwtjackson.client.advanced.identity.ObjectIdDeserializationGwtTest;
 import com.github.nmorel.gwtjackson.client.advanced.identity.ObjectIdGwtTest;
 import com.github.nmorel.gwtjackson.client.advanced.identity.ObjectIdSerializationGwtTest;
@@ -312,6 +313,7 @@ public class GwtJacksonTestSuite extends TestCase {
         suite.addTestSuite( JavaScriptObjectGwtTest.class );
         suite.addTestSuite( DeserializeAsGwtTest.class );
 
+
         // Polymorphism
         suite.addTestSuite( PolymorphismNoTypeInfoGwtTest.class );
         suite.addTestSuite( PolymorphismIdClassAsPropertyGwtTest.class );
@@ -330,7 +332,8 @@ public class GwtJacksonTestSuite extends TestCase {
         suite.addTestSuite( ObjectIdSerializationGwtTest.class );
         suite.addTestSuite( ObjectIdWithPolymorphicGwtTest.class );
         suite.addTestSuite( ObjectIdWithEqualsGwtTest.class );
-
+        suite.addTestSuite( ObjectIdBackReferenceGwtTest.class);
+        
         // Options
         suite.addTestSuite( IndentGwtTest.class );
         suite.addTestSuite( DateOptionsGwtTest.class );

--- a/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/client/advanced/identity/ObjectIdBackReferenceGwtTest.java
+++ b/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/client/advanced/identity/ObjectIdBackReferenceGwtTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2013 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.client.advanced.identity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.github.nmorel.gwtjackson.client.GwtJacksonTestCase;
+import com.github.nmorel.gwtjackson.client.ObjectMapper;
+import com.github.nmorel.gwtjackson.shared.ObjectMapperTester;
+import com.google.gwt.core.client.GWT;
+
+/**
+ * @author Nicolas Morel
+ */
+public class ObjectIdBackReferenceGwtTest extends GwtJacksonTestCase {
+	@JsonIdentityInfo( generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id" )
+	public static class Owner {
+		private List<Child> children; 
+		
+		@JsonCreator
+		Owner( @JsonProperty("children") List<Child> children) {
+			this.children = children;
+		}
+		public Owner() {
+			children = new ArrayList<Child>();
+		}
+		@JsonProperty("children")
+		public List<Child> getChildren() {
+			return children;
+		}
+		
+		public Child addChild( String name ) {
+			Child child = new Child( name );
+			child.setOwner(this);
+			children.add(child);
+			return child;
+		}
+	}
+	
+	public static class Child {
+		private Owner owner;
+		private String name;
+		
+		@JsonCreator
+		public Child( @JsonProperty("name") String name ) {
+			this( null, name );
+		}
+		
+		public Child( Owner owner, String name ) {
+			this.owner = owner;
+			this.name = name;
+		}
+		
+		@JsonProperty("owner")
+		@JsonIdentityReference
+		void setOwner( Owner owner ) {
+			this.owner = owner;
+		}
+		
+		public Owner getOwner() {
+			return owner;
+		}
+		
+		
+		@JsonProperty("name")
+		public String getName() {
+			return name;
+		}
+		
+		public void setName( String name ) {
+			this.name = name;
+		}
+	}
+ 
+
+    public interface OwnerMapper extends ObjectMapper<Owner>, ObjectMapperTester<Owner> {
+        static OwnerMapper INSTANCE = GWT.create( OwnerMapper.class );
+    }
+    
+    public void testSerialize() {
+    	Owner origOwner = new Owner();
+    	Child origChild = origOwner.addChild("item1");
+    	String json = OwnerMapper.INSTANCE.write(origOwner);
+    	Owner jsonOwner = OwnerMapper.INSTANCE.read(json);
+    	Child jsonChild = jsonOwner.getChildren().get(0);
+    	assertEquals("item1", jsonChild.getName());
+    }
+}

--- a/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/client/advanced/identity/ObjectIdBackReferenceTest.java
+++ b/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/client/advanced/identity/ObjectIdBackReferenceTest.java
@@ -1,0 +1,86 @@
+package com.github.nmorel.gwtjackson.client.advanced.identity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gwt.core.client.GWT;
+
+import junit.framework.TestCase;
+
+public class ObjectIdBackReferenceTest extends TestCase {
+	@JsonIdentityInfo( generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id" )
+	public static class Owner {
+		private List<Child> children; 
+		
+		@JsonCreator
+		Owner( @JsonProperty("children") List<Child> children) {
+			this.children = children;
+		}
+		public Owner() {
+			children = new ArrayList<Child>();
+		}
+		@JsonProperty("children")
+		public List<Child> getChildren() {
+			return children;
+		}
+		
+		public Child addChild( String name ) {
+			Child child = new Child( name );
+			child.setOwner(this);
+			children.add(child);
+			return child;
+		}
+	}
+	
+	public static class Child {
+		private Owner owner;
+		private String name;
+		
+		@JsonCreator
+		public Child( @JsonProperty("name") String name ) {
+			this( null, name );
+		}
+		
+		public Child( Owner owner, String name ) {
+			this.owner = owner;
+			this.name = name;
+		}
+		
+		@JsonProperty("owner")
+		@JsonIdentityReference
+		void setOwner( Owner owner ) {
+			this.owner = owner;
+		}
+		
+		public Owner getOwner() {
+			return owner;
+		}
+		
+		
+		@JsonProperty("name")
+		public String getName() {
+			return name;
+		}
+		
+		public void setName( String name ) {
+			this.name = name;
+		}
+	}
+    
+    public void testSerialize() throws Exception {
+    	ObjectMapper mapper = new ObjectMapper();
+    	Owner origOwner = new Owner();
+    	Child origChild = origOwner.addChild("item1");
+    	String json = mapper.writeValueAsString(origOwner);
+    	Owner jsonOwner = mapper.readValue(json, Owner.class);
+    	Child jsonChild = jsonOwner.getChildren().get(0);
+    	assertEquals("item1", jsonChild.getName());
+    }
+}


### PR DESCRIPTION
Here is an example testcase that shows that the JsonIdentityInfo is not properly working when using a backpointer. It works fine with regular Jackson, but not with gwt-jackson. I don’t have a solution for this problem, since I don’t know the sources of gwt-jackson well enough to contribute a patch at this moment.