### PR TITLE
add missing javax.annotation from gwt-2.8.0-rc1 onwards

### DIFF
--- a/gwt-jackson/pom.xml
+++ b/gwt-jackson/pom.xml
@@ -141,6 +141,12 @@
       <artifactId>gwt-dev</artifactId>
     </dependency>
 
+    <!-- javax.annotations -->
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+
     <!-- Jackson annotation dependencies -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
     <jackson.version>2.7.2</jackson.version>
     <javapoet.version>1.0.0</javapoet.version>
     <junit.version>4.12</junit.version>
+    <findbugs.version>3.0.0</findbugs.version>
   </properties>
 
   <dependencyManagement>
@@ -108,6 +109,13 @@
         <artifactId>gwt-dev</artifactId>
         <version>${gwt.version}</version>
         <scope>provided</scope>
+      </dependency>
+
+      <!-- javax.annotations -->
+      <dependency>
+	<groupId>com.google.code.findbugs</groupId>
+	<artifactId>jsr305</artifactId>
+	<version>${findbugs.version}</version>
       </dependency>
 
       <!-- Jackson dependencies -->


### PR DESCRIPTION
this is PR to fix https://github.com/gwtproject/gwt/issues/9382
in case GWT decides not to include this findbugs jar anymore and to keep GWT-2.8.0-rc1 working with gwt-jackson

there are still issues with gwt-2.8.0-beta1 with the a NPE in junit - not sure where this comes from. but with this PR gwt-2.8.0-beta1 and gwt-2.8.0-rc1 both have the same junit problem.