### PR TITLE
use latest resty release

### DIFF
--- a/examples/restygwt/pom.xml
+++ b/examples/restygwt/pom.xml
@@ -17,16 +17,6 @@
     <gwt.module>com.github.nmorel.gwtjackson.hello.HelloRestyGWT</gwt.module>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>oss-sonatype-snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -41,7 +31,7 @@
     <dependency>
       <groupId>org.fusesource.restygwt</groupId>
       <artifactId>restygwt</artifactId>
-      <version>2.2.0-SNAPSHOT</version>
+      <version>2.2.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
just updated the rest-gwt example using the latest release and removed the snapshot repo