### PR TITLE
Big fix for nextValue and decimal numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ With Maven
 <dependency>
   <groupId>com.github.nmorel.gwtjackson</groupId>
   <artifactId>gwt-jackson</artifactId>
-  <version>0.14.1</version>
+  <version>0.14.2</version>
   <scope>provided</scope>
 </dependency>
 ```

--- a/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/client/stream/impl/NonBufferedJsonReaderTest.java
+++ b/gwt-jackson/src/test/java/com/github/nmorel/gwtjackson/client/stream/impl/NonBufferedJsonReaderTest.java
@@ -18,6 +18,7 @@ package com.github.nmorel.gwtjackson.client.stream.impl;
 
 import com.github.nmorel.gwtjackson.client.stream.AbstractJsonReaderTest;
 import com.github.nmorel.gwtjackson.client.stream.JsonReader;
+import com.github.nmorel.gwtjackson.client.stream.JsonToken;
 
 /**
  * @author Nicolas Morel
@@ -27,5 +28,15 @@ public class NonBufferedJsonReaderTest extends AbstractJsonReaderTest {
     @Override
     public JsonReader newJsonReader( String input ) {
         return new NonBufferedJsonReader( input );
+    }
+
+    // Below test only works with NonBufferedJsonReader - would need to update
+    // DefaultJsonReader to also support this
+    public void testNextValueWithDecimalValue() {
+        JsonReader reader = newJsonReader( "[1.343423]" );
+        reader.beginArray();
+        assertEquals( "1.343423", reader.nextValue() );
+        reader.endArray();
+        assertEquals( JsonToken.END_DOCUMENT, reader.peek() );
     }
 }


### PR DESCRIPTION
Fixes #108 

Decimal numbers now correctly not escaped when retrieved as string using nextValue() and includes clean-up of number handling in NonBufferedJsonReader (all tests are passing and included one new test for the issue this fix relates to - note only implemented fix in NonBufferedJsonReader)