### PR TITLE
New extensions: Objectify and Remote Logging

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -3,6 +3,7 @@ gwt-jackson-extensions
 This submodule contains all the extensions of [gwt-jackson](https://github.com/nmorel/gwt-jackson).
 * [Guava](guava) : Add support for Guava types like Optional or ImmutableList
 * [Objectify](objectify) : Add support for Objectify types like Ref or Key
+* [Remote Logging](remotelogging) : Add support for remote logging of Throwable
 
 
 Copyright and license

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -2,6 +2,7 @@ gwt-jackson-extensions
 =====
 This submodule contains all the extensions of [gwt-jackson](https://github.com/nmorel/gwt-jackson).
 * [Guava](guava) : Add support for Guava types like Optional or ImmutableList
+* [Objectify](objectify) : Add support for Objectify types like Ref or Key
 
 
 Copyright and license

--- a/extensions/objectify/README.md
+++ b/extensions/objectify/README.md
@@ -1,0 +1,17 @@
+gwt-jackson-objectify
+=====
+This extension contains serializer and deserializer for Objectify types like Ref or Key.
+
+To use it add the library to your classpath (for maven, the artifactId is `gwt-jackson-objectify`):
+1. Client-side: add `<inherits name="com.github.nmorel.gwtjackson.objectify.GwtJacksonObjectify" />` to your module descriptor XML file.
+2. Server-side: register the Jackson module `ObjectifyJacksonModule`
+
+Full working demo project: [gwt-storage-objectify](https://github.com/freddyboucher/gwt-storage-objectify)
+
+Important note: Ref\<T\> is serialized as DeadRef\<T\> and the T value is serialized if it is loaded into the session.
+
+
+Copyright and license
+-------------
+
+Copyright 2013 Nicolas Morel under the [Apache 2.0 license](LICENSE).

--- a/extensions/objectify/pom.xml
+++ b/extensions/objectify/pom.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Nicolas Morel
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>com.github.nmorel.gwtjackson</groupId>
+    <artifactId>gwt-jackson-extensions</artifactId>
+    <version>0.14.3-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>gwt-jackson-objectify</artifactId>
+
+  <name>gwt-jackson :: Extensions :: Objectify</name>
+  <description>Extension to support Objectify types like Ref or Key</description>
+
+  <properties>
+    <gae.version>1.9.60</gae.version>
+  </properties>
+
+  <dependencies>
+    <!-- Objectify -->
+    <dependency>
+      <groupId>com.googlecode.objectify</groupId>
+      <artifactId>objectify</artifactId>
+      <version>5.1.21</version>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.objectify</groupId>
+      <artifactId>objectify</artifactId>
+      <version>5.1.21</version>
+      <classifier>sources</classifier>
+    </dependency>
+
+    <!-- Google App Engine -->
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>${gae.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-labs</artifactId>
+      <version>${gae.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-stubs</artifactId>
+      <version>${gae.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-testing</artifactId>
+      <version>${gae.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/client/**/*TestCase.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>gwt-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>packaging</id>
+            <goals>
+              <goal>resources</goal>
+            </goals>
+            <configuration>
+              <modules>
+                <module>com.github.nmorel.gwtjackson.objectify.GwtJacksonObjectify</module>
+              </modules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>test-dev-mode</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <module>com.github.nmorel.gwtjackson.objectify.GwtJacksonObjectifyTest</module>
+              <out>${project.build.directory}/gwt/test/dev</out>
+            </configuration>
+          </execution>
+          <execution>
+            <id>test-prod</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <module>com.github.nmorel.gwtjackson.objectify.GwtJacksonObjectifyTest</module>
+              <out>${project.build.directory}/gwt/test/prod</out>
+              <productionMode>true</productionMode>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/KeyJsonDeserializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/KeyJsonDeserializer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import com.github.nmorel.gwtjackson.client.JsonDeserializationContext;
+import com.github.nmorel.gwtjackson.client.JsonDeserializer;
+import com.github.nmorel.gwtjackson.client.JsonDeserializerParameters;
+import com.github.nmorel.gwtjackson.client.stream.JsonReader;
+import com.github.nmorel.gwtjackson.objectify.shared.KeyConstant;
+import com.googlecode.objectify.Key;
+
+public class KeyJsonDeserializer<T> extends JsonDeserializer<Key<T>> {
+
+    private static final KeyJsonDeserializer INSTANCE = new KeyJsonDeserializer();
+
+    public static <T> KeyJsonDeserializer<T> newInstance( JsonDeserializer<T> deserializer ) {
+        return INSTANCE;
+    }
+
+    public static <T> KeyJsonDeserializer<T> getInstance() {
+        return INSTANCE;
+    }
+
+    private KeyJsonDeserializer() {
+    }
+
+    @Override
+    protected Key<T> doDeserialize( JsonReader reader, JsonDeserializationContext ctx, JsonDeserializerParameters params ) {
+        reader.beginObject();
+        if ( !KeyConstant.RAW.equals( reader.nextName() ) ) {
+            throw ctx.traceError( "Missing " + KeyConstant.RAW + " property.", reader );
+        }
+        com.google.appengine.api.datastore.Key raw = RawKeyJsonDeserializer.getInstance().deserialize( reader, ctx, params );
+        reader.endObject();
+        return Key.create( raw );
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/KeyJsonSerializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/KeyJsonSerializer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import com.github.nmorel.gwtjackson.client.JsonSerializationContext;
+import com.github.nmorel.gwtjackson.client.JsonSerializer;
+import com.github.nmorel.gwtjackson.client.JsonSerializerParameters;
+import com.github.nmorel.gwtjackson.client.stream.JsonWriter;
+import com.github.nmorel.gwtjackson.objectify.shared.KeyConstant;
+import com.googlecode.objectify.Key;
+
+public class KeyJsonSerializer<T> extends JsonSerializer<Key<T>> {
+
+    private static final KeyJsonSerializer INSTANCE = new KeyJsonSerializer();
+
+    public static <T> KeyJsonSerializer<T> newInstance( JsonSerializer<T> serializer ) {
+        return INSTANCE;
+    }
+
+    public static KeyJsonSerializer getInstance() {
+        return INSTANCE;
+    }
+
+    private KeyJsonSerializer() {
+    }
+
+    @Override
+    protected void doSerialize( JsonWriter writer, Key<T> key, JsonSerializationContext ctx, JsonSerializerParameters params ) {
+        writer.beginObject();
+        writer.name( KeyConstant.RAW );
+        RawKeyJsonSerializer.getInstance().serialize( writer, key.getRaw(), ctx, params );
+        writer.endObject();
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/KeyKeyDeserializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/KeyKeyDeserializer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import com.github.nmorel.gwtjackson.client.JsonDeserializationContext;
+import com.github.nmorel.gwtjackson.client.JsonDeserializer;
+import com.github.nmorel.gwtjackson.client.deser.map.key.KeyDeserializer;
+import com.github.nmorel.gwtjackson.client.stream.JsonReader;
+import com.googlecode.objectify.Key;
+
+public class KeyKeyDeserializer<T> extends KeyDeserializer<Key<T>> {
+
+    public static <T> KeyKeyDeserializer<T> newInstance( JsonDeserializer<T> deserializer ) {
+        return new KeyKeyDeserializer<T>( deserializer );
+    }
+
+    private final KeyJsonDeserializer<T> deserializer;
+
+    private KeyKeyDeserializer(JsonDeserializer<T> deserializer) {
+        if ( null == deserializer ) {
+            throw new IllegalArgumentException( "deserializer can't be null" );
+        }
+        this.deserializer = KeyJsonDeserializer.newInstance( deserializer );
+    }
+
+    @Override
+    protected Key<T> doDeserialize( String key, JsonDeserializationContext ctx ) {
+        JsonReader jsonReader = ctx.newJsonReader( key );
+        return deserializer.deserialize( jsonReader, ctx );
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/KeyKeySerializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/KeyKeySerializer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import com.github.nmorel.gwtjackson.client.JsonSerializationContext;
+import com.github.nmorel.gwtjackson.client.JsonSerializer;
+import com.github.nmorel.gwtjackson.client.ser.map.key.KeySerializer;
+import com.github.nmorel.gwtjackson.client.stream.JsonWriter;
+import com.googlecode.objectify.Key;
+
+public class KeyKeySerializer<T> extends KeySerializer<Key<T>> {
+
+    public static <T> KeyKeySerializer<T> newInstance( JsonSerializer<T> serializer ) {
+        return new KeyKeySerializer<T>( serializer );
+    }
+
+    private final KeyJsonSerializer<T> serializer;
+
+    private KeyKeySerializer( JsonSerializer<T> serializer ) {
+        if ( null == serializer ) {
+            throw new IllegalArgumentException( "serializer cannot be null" );
+        }
+        this.serializer = KeyJsonSerializer.newInstance( serializer );
+    }
+
+    @Override
+    protected String doSerialize( Key<T> value, JsonSerializationContext ctx ) {
+        JsonWriter jsonWriter = ctx.newJsonWriter();
+        serializer.serialize( jsonWriter, value, ctx );
+        jsonWriter.close();
+        return jsonWriter.getOutput();
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/RawKeyJsonDeserializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/RawKeyJsonDeserializer.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import com.github.nmorel.gwtjackson.client.JsonDeserializationContext;
+import com.github.nmorel.gwtjackson.client.JsonDeserializer;
+import com.github.nmorel.gwtjackson.client.JsonDeserializerParameters;
+import com.github.nmorel.gwtjackson.client.stream.JsonReader;
+import com.github.nmorel.gwtjackson.objectify.shared.RawKeyConstant;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+
+public class RawKeyJsonDeserializer extends JsonDeserializer<Key> {
+
+    private static final RawKeyJsonDeserializer INSTANCE = new RawKeyJsonDeserializer();
+
+    public static RawKeyJsonDeserializer getInstance() {
+        return INSTANCE;
+    }
+
+    private RawKeyJsonDeserializer() { }
+
+    @Override
+    protected Key doDeserialize( JsonReader reader, JsonDeserializationContext ctx, JsonDeserializerParameters params ) {
+        reader.beginObject();
+        Key parent = null;
+        String kind = null;
+        Long id = null;
+        String name = null;
+
+        while ( reader.hasNext() ) {
+            String nextName = reader.nextName();
+            if ( RawKeyConstant.PARENT.equals( nextName ) ) {
+                parent = deserialize( reader, ctx );
+
+            } else if ( RawKeyConstant.KIND.equals( nextName ) ) {
+                kind = reader.nextString();
+
+            } else if ( RawKeyConstant.ID.equals( nextName ) ) {
+                id = reader.nextLong();
+
+            } else if ( RawKeyConstant.NAME.equals( nextName ) ) {
+                try {
+                    name = reader.nextString();
+                } catch ( Exception e ) {
+                    reader.nextNull();
+                }
+
+            } else {
+                throw ctx.traceError( "Unknown " + nextName + " property.", reader );
+            }
+        }
+
+        reader.endObject();
+
+        if ( id == null ) {
+            throw ctx.traceError( "Missing " + RawKeyConstant.ID + " property.", reader );
+        } else if ( id != 0 ) {
+            return KeyFactory.createKey( parent, kind, id );
+        }
+
+        return KeyFactory.createKey( parent, kind, name );
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/RawKeyJsonSerializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/RawKeyJsonSerializer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import com.github.nmorel.gwtjackson.client.JsonSerializationContext;
+import com.github.nmorel.gwtjackson.client.JsonSerializer;
+import com.github.nmorel.gwtjackson.client.JsonSerializerParameters;
+import com.github.nmorel.gwtjackson.client.stream.JsonWriter;
+import com.github.nmorel.gwtjackson.objectify.shared.RawKeyConstant;
+import com.google.appengine.api.datastore.Key;
+
+public class RawKeyJsonSerializer extends JsonSerializer<Key> {
+
+    private static final RawKeyJsonSerializer INSTANCE = new RawKeyJsonSerializer();
+
+    public static RawKeyJsonSerializer getInstance() {
+        return INSTANCE;
+    }
+
+    private RawKeyJsonSerializer() { }
+
+    @Override
+    protected void doSerialize( JsonWriter writer, Key key, JsonSerializationContext ctx, JsonSerializerParameters params ) {
+        writer.beginObject();
+        if ( key.getParent() != null || ctx.isSerializeNulls() ) {
+            writer.name( RawKeyConstant.PARENT );
+            serialize( writer, key.getParent(), ctx, params );
+        }
+        if ( key.getKind() != null || ctx.isSerializeNulls() ) {
+            writer.name( RawKeyConstant.KIND ).value( key.getKind() );
+        }
+        writer.name( RawKeyConstant.ID ).value( key.getId() );
+        if ( key.getName() != null || ctx.isSerializeNulls() ) {
+            writer.name( RawKeyConstant.NAME ).value( key.getName() );
+        }
+        writer.endObject();
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/RawKeyKeyDeserializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/RawKeyKeyDeserializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import com.github.nmorel.gwtjackson.client.JsonDeserializationContext;
+import com.github.nmorel.gwtjackson.client.deser.map.key.KeyDeserializer;
+import com.github.nmorel.gwtjackson.client.stream.JsonReader;
+import com.google.appengine.api.datastore.Key;
+
+public class RawKeyKeyDeserializer extends KeyDeserializer<Key> {
+
+    private static final RawKeyKeyDeserializer INSTANCE = new RawKeyKeyDeserializer();
+
+    public static RawKeyKeyDeserializer getInstance() {
+        return INSTANCE;
+    }
+
+    private RawKeyKeyDeserializer() { }
+
+    @Override
+    protected Key doDeserialize( String key, JsonDeserializationContext ctx ) {
+        JsonReader jsonReader = ctx.newJsonReader( key );
+        return RawKeyJsonDeserializer.getInstance().deserialize( jsonReader, ctx );
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/RawKeyKeySerializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/RawKeyKeySerializer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import com.github.nmorel.gwtjackson.client.JsonSerializationContext;
+import com.github.nmorel.gwtjackson.client.ser.map.key.KeySerializer;
+import com.github.nmorel.gwtjackson.client.stream.JsonWriter;
+import com.google.appengine.api.datastore.Key;
+
+public class RawKeyKeySerializer extends KeySerializer<Key> {
+
+    private static final RawKeyKeySerializer INSTANCE = new RawKeyKeySerializer();
+
+    public static RawKeyKeySerializer getInstance() {
+        return INSTANCE;
+    }
+
+    private RawKeyKeySerializer() { }
+
+    @Override
+    protected String doSerialize( Key value, JsonSerializationContext ctx ) {
+        JsonWriter jsonWriter = ctx.newJsonWriter();
+        RawKeyJsonSerializer.getInstance().serialize( jsonWriter, value, ctx );
+        jsonWriter.close();
+        return jsonWriter.getOutput();
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/RefJsonDeserializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/RefJsonDeserializer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import com.github.nmorel.gwtjackson.client.JsonDeserializationContext;
+import com.github.nmorel.gwtjackson.client.JsonDeserializer;
+import com.github.nmorel.gwtjackson.client.JsonDeserializerParameters;
+import com.github.nmorel.gwtjackson.client.stream.JsonReader;
+import com.github.nmorel.gwtjackson.objectify.shared.RefConstant;
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.Ref;
+import com.googlecode.objectify.impl.ref.DeadRef;
+
+public class RefJsonDeserializer<T> extends JsonDeserializer<Ref<T>> {
+
+    public static <T> RefJsonDeserializer<T> newInstance( JsonDeserializer<T> deserializer ) {
+        return new RefJsonDeserializer<T>( deserializer );
+    }
+
+    private final JsonDeserializer<T> deserializer;
+
+    private RefJsonDeserializer( JsonDeserializer<T> deserializer ) {
+        if ( null == deserializer ) {
+            throw new IllegalArgumentException( "deserializer can't be null" );
+        }
+        this.deserializer = deserializer;
+    }
+
+    @Override
+    protected Ref<T> doDeserialize( JsonReader reader, JsonDeserializationContext ctx, JsonDeserializerParameters params ) {
+        reader.beginObject();
+        Key<T> key = null;
+        T value = null;
+        while ( reader.hasNext() ) {
+            String nextName = reader.nextName();
+            if ( RefConstant.KEY.equals( nextName ) ) {
+                key = KeyJsonDeserializer.<T>getInstance().deserialize( reader, ctx, params );
+
+            } else if ( RefConstant.VALUE.equals( nextName ) ) {
+                value = deserializer.deserialize( reader, ctx, params );
+
+            }
+        }
+        reader.endObject();
+        if ( key == null ) {
+            throw ctx.traceError( "Missing " + RefConstant.KEY + " property.", reader );
+        }
+        return new DeadRef<T>( key, value );
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/RefJsonSerializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/RefJsonSerializer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import com.github.nmorel.gwtjackson.client.JsonSerializationContext;
+import com.github.nmorel.gwtjackson.client.JsonSerializer;
+import com.github.nmorel.gwtjackson.client.JsonSerializerParameters;
+import com.github.nmorel.gwtjackson.client.stream.JsonWriter;
+import com.github.nmorel.gwtjackson.objectify.shared.RefConstant;
+import com.googlecode.objectify.Ref;
+
+public class RefJsonSerializer<T> extends JsonSerializer<Ref<T>> {
+
+    public static <T> RefJsonSerializer<T> newInstance( JsonSerializer<T> serializer ) {
+        return new RefJsonSerializer<T>( serializer );
+    }
+
+    private final JsonSerializer<T> serializer;
+
+    private RefJsonSerializer( JsonSerializer<T> serializer ) {
+        if ( null == serializer ) {
+            throw new IllegalArgumentException( "serializer cannot be null" );
+        }
+        this.serializer = serializer;
+    }
+
+    @Override
+    protected void doSerialize( JsonWriter writer, Ref<T> ref, JsonSerializationContext ctx, JsonSerializerParameters params ) {
+        writer.beginObject();
+        writer.name( RefConstant.KEY );
+        KeyJsonSerializer.getInstance().serialize( writer, ref.getKey(), ctx, params );
+        writer.name( RefConstant.VALUE );
+        serializer.serialize( writer, ref.getValue(), ctx, params );
+        writer.endObject();
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/RefKeyDeserializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/RefKeyDeserializer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import com.github.nmorel.gwtjackson.client.JsonDeserializationContext;
+import com.github.nmorel.gwtjackson.client.JsonDeserializer;
+import com.github.nmorel.gwtjackson.client.deser.map.key.KeyDeserializer;
+import com.github.nmorel.gwtjackson.client.stream.JsonReader;
+import com.googlecode.objectify.Ref;
+
+public class RefKeyDeserializer<T> extends KeyDeserializer<Ref<T>> {
+
+    public static <T> RefKeyDeserializer<T> newInstance( JsonDeserializer<T> deserializer ) {
+        return new RefKeyDeserializer<T>( deserializer );
+    }
+
+    private final JsonDeserializer<T> deserializer;
+
+    private RefKeyDeserializer(JsonDeserializer<T> deserializer) {
+        if ( null == deserializer ) {
+            throw new IllegalArgumentException( "deserializer can't be null" );
+        }
+        this.deserializer = deserializer;
+    }
+
+    @Override
+    protected Ref<T> doDeserialize( String key, JsonDeserializationContext ctx ) {
+        JsonReader jsonReader = ctx.newJsonReader( key );
+        return RefJsonDeserializer.newInstance( deserializer ).deserialize( jsonReader, ctx );
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/RefKeySerializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/client/RefKeySerializer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import com.github.nmorel.gwtjackson.client.JsonSerializationContext;
+import com.github.nmorel.gwtjackson.client.JsonSerializer;
+import com.github.nmorel.gwtjackson.client.ser.map.key.KeySerializer;
+import com.github.nmorel.gwtjackson.client.stream.JsonWriter;
+import com.googlecode.objectify.Ref;
+
+public class RefKeySerializer<T> extends KeySerializer<Ref<T>> {
+
+    public static <T> RefKeySerializer<T> newInstance( JsonSerializer<T> serializer ) {
+        return new RefKeySerializer<T>( serializer );
+    }
+
+    private final JsonSerializer<T> serializer;
+
+    private RefKeySerializer( JsonSerializer<T> serializer ) {
+        if ( null == serializer ) {
+            throw new IllegalArgumentException( "serializer cannot be null" );
+        }
+        this.serializer = serializer;
+    }
+
+    @Override
+    protected String doSerialize( Ref<T> value, JsonSerializationContext ctx ) {
+        JsonWriter jsonWriter = ctx.newJsonWriter();
+        RefJsonSerializer.newInstance( serializer ).serialize( jsonWriter, value, ctx );
+        jsonWriter.close();
+        return jsonWriter.getOutput();
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/rebind/ObjectifyConfiguration.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/rebind/ObjectifyConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.rebind;
+
+import com.github.nmorel.gwtjackson.client.AbstractConfiguration;
+import com.github.nmorel.gwtjackson.objectify.client.KeyJsonDeserializer;
+import com.github.nmorel.gwtjackson.objectify.client.KeyJsonSerializer;
+import com.github.nmorel.gwtjackson.objectify.client.KeyKeyDeserializer;
+import com.github.nmorel.gwtjackson.objectify.client.KeyKeySerializer;
+import com.github.nmorel.gwtjackson.objectify.client.RawKeyJsonDeserializer;
+import com.github.nmorel.gwtjackson.objectify.client.RawKeyJsonSerializer;
+import com.github.nmorel.gwtjackson.objectify.client.RawKeyKeyDeserializer;
+import com.github.nmorel.gwtjackson.objectify.client.RawKeyKeySerializer;
+import com.github.nmorel.gwtjackson.objectify.client.RefJsonDeserializer;
+import com.github.nmorel.gwtjackson.objectify.client.RefJsonSerializer;
+import com.github.nmorel.gwtjackson.objectify.client.RefKeyDeserializer;
+import com.github.nmorel.gwtjackson.objectify.client.RefKeySerializer;
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.Ref;
+
+public class ObjectifyConfiguration extends AbstractConfiguration {
+
+    @Override
+    protected void configure() {
+        type( com.google.appengine.api.datastore.Key.class ).serializer( RawKeyJsonSerializer.class )
+                .deserializer( RawKeyJsonDeserializer.class );
+        type( Key.class ).serializer( KeyJsonSerializer.class ).deserializer( KeyJsonDeserializer.class );
+        type( Ref.class ).serializer( RefJsonSerializer.class ).deserializer( RefJsonDeserializer.class );
+
+        key( com.google.appengine.api.datastore.Key.class ).serializer( RawKeyKeySerializer.class )
+                .deserializer( RawKeyKeyDeserializer.class );
+        key( Key.class ).serializer( KeyKeySerializer.class ).deserializer( KeyKeyDeserializer.class );
+        key( Ref.class ).serializer( RefKeySerializer.class ).deserializer( RefKeyDeserializer.class );
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/KeyJsonSerializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/KeyJsonSerializer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.server;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.googlecode.objectify.Key;
+
+public class KeyJsonSerializer extends JsonSerializer<Key> {
+
+    @Override
+    public void serialize( Key value, JsonGenerator jgen, SerializerProvider provider ) throws IOException {
+        if ( value != null || Include.NON_NULL != provider.getConfig().getDefaultPropertyInclusion().getValueInclusion() ) {
+            StringWriter writer = new StringWriter();
+            JsonGenerator jsonGenerator = jgen.getCodec().getFactory().createGenerator( writer );
+            jgen.getCodec().writeValue( jsonGenerator, value );
+            jsonGenerator.close();
+            jgen.writeFieldName( writer.toString() );
+        }
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/KeyStdDeserializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/KeyStdDeserializer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.server;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.github.nmorel.gwtjackson.objectify.shared.KeyConstant;
+import com.googlecode.objectify.Key;
+
+public class KeyStdDeserializer extends StdDeserializer<Key> {
+
+    public KeyStdDeserializer() {
+        super( Key.class );
+    }
+
+    @Override
+    public Key deserialize( JsonParser jp, DeserializationContext ctxt ) throws IOException {
+        JsonNode node = jp.readValueAsTree();
+
+        JsonParser rawJsonParser = node.get( KeyConstant.RAW ).traverse();
+        rawJsonParser.setCodec( jp.getCodec() );
+        com.google.appengine.api.datastore.Key key = rawJsonParser.readValueAs( com.google.appengine.api.datastore.Key.class );
+
+        return Key.create( key );
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/KeyStdKeyDeserializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/KeyStdKeyDeserializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.server;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdKeyDeserializer;
+import com.googlecode.objectify.Key;
+
+public class KeyStdKeyDeserializer extends StdKeyDeserializer {
+
+    private final KeyStdDeserializer keyJsonDeserializer = new KeyStdDeserializer();
+
+    public KeyStdKeyDeserializer() {
+        super( StdKeyDeserializer.TYPE_CLASS, Key.class );
+    }
+
+    @Override
+    public Object deserializeKey( String key, DeserializationContext ctxt ) throws IOException {
+        JsonParser jsonParser = ctxt.getParser().getCodec().getFactory().createParser( key );
+        return keyJsonDeserializer.deserialize( jsonParser, ctxt );
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/KeyStdSerializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/KeyStdSerializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.server;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.github.nmorel.gwtjackson.objectify.shared.KeyConstant;
+import com.googlecode.objectify.Key;
+
+public class KeyStdSerializer extends StdSerializer<Key> {
+
+    public KeyStdSerializer() {
+        super( Key.class );
+    }
+
+    @Override
+    public void serialize( Key value, JsonGenerator jgen, SerializerProvider provider ) throws IOException {
+        jgen.writeStartObject();
+        jgen.writeObjectField( KeyConstant.RAW, value.getRaw() );
+        jgen.writeEndObject();
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/ObjectifyJacksonModule.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/ObjectifyJacksonModule.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.server;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.Ref;
+
+public class ObjectifyJacksonModule extends SimpleModule {
+
+    private static final long serialVersionUID = 1L;
+
+    public ObjectifyJacksonModule() {
+        super( "Objectify", Version.unknownVersion() );
+
+        // Objectify Key
+        addSerializer( Key.class, new KeyStdSerializer() );
+        addDeserializer( Key.class, new KeyStdDeserializer() );
+        addKeySerializer( Key.class, new KeyJsonSerializer() );
+        addKeyDeserializer( Key.class, new KeyStdKeyDeserializer() );
+
+        // Objectify Ref
+        addSerializer( Ref.class, new RefStdSerializer() );
+        addDeserializer( Ref.class, new RefStdDeserializer() );
+        addKeySerializer( Ref.class, new RefJsonSerializer() );
+        addKeyDeserializer( Ref.class, new RefStdKeyDeserializer() );
+
+        // Native datastore Key
+        addSerializer( com.google.appengine.api.datastore.Key.class, new RawKeyStdSerializer() );
+        addDeserializer( com.google.appengine.api.datastore.Key.class, new RawKeyStdDeserializer() );
+        addKeySerializer( com.google.appengine.api.datastore.Key.class, new RawKeyJsonSerializer() );
+        addKeyDeserializer( com.google.appengine.api.datastore.Key.class, new RawKeyStdKeyDeserializer() );
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/RawKeyJsonSerializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/RawKeyJsonSerializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.server;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.google.appengine.api.datastore.Key;
+
+public class RawKeyJsonSerializer extends JsonSerializer<Key> {
+
+    private final RawKeyStdSerializer rawKeyStdSerializer = new RawKeyStdSerializer();
+
+    @Override
+    public void serialize( Key value, JsonGenerator jgen, SerializerProvider provider ) throws IOException {
+        StringWriter writer = new StringWriter();
+        JsonGenerator jsonGenerator = jgen.getCodec().getFactory().createGenerator( writer );
+        rawKeyStdSerializer.serialize( value, jsonGenerator, provider );
+        jsonGenerator.close();
+        jgen.writeFieldName( writer.toString() );
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/RawKeyStdDeserializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/RawKeyStdDeserializer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.server;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.github.nmorel.gwtjackson.objectify.shared.RawKeyConstant;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+
+public class RawKeyStdDeserializer extends StdDeserializer<Key> {
+
+    public RawKeyStdDeserializer() {
+        super( Key.class );
+    }
+
+    @Override
+    public Key deserialize( JsonParser jp, DeserializationContext ctxt ) throws IOException {
+        JsonNode node = jp.readValueAsTree();
+        Key parent = null;
+        if ( node.has( RawKeyConstant.PARENT ) ) {
+            JsonParser parentJsonParser = node.get( RawKeyConstant.PARENT ).traverse();
+            parentJsonParser.setCodec( jp.getCodec() );
+            parent = parentJsonParser.readValueAs( Key.class );
+        }
+        String kind = null;
+        if ( node.has( RawKeyConstant.KIND ) ) {
+            kind = node.get( RawKeyConstant.KIND ).asText();
+        }
+        long id = node.get( RawKeyConstant.ID ).asLong();
+
+        if ( id != 0 ) {
+            return KeyFactory.createKey( parent, kind, id );
+        }
+
+        String name = null;
+        if ( node.has( RawKeyConstant.NAME ) ) {
+            name = node.get( RawKeyConstant.NAME ).asText();
+        }
+        return KeyFactory.createKey( parent, kind, name );
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/RawKeyStdKeyDeserializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/RawKeyStdKeyDeserializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.server;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdKeyDeserializer;
+import com.google.appengine.api.datastore.Key;
+
+public class RawKeyStdKeyDeserializer extends StdKeyDeserializer {
+
+    private final RawKeyStdDeserializer rawKeyStdDeserializer = new RawKeyStdDeserializer();
+
+    public RawKeyStdKeyDeserializer() {
+        super( StdKeyDeserializer.TYPE_CLASS, Key.class );
+    }
+
+    @Override
+    public Object deserializeKey( String key, DeserializationContext ctxt ) throws IOException {
+        JsonParser jsonParser = ctxt.getParser().getCodec().getFactory().createParser( key );
+        return rawKeyStdDeserializer.deserialize( jsonParser, ctxt );
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/RawKeyStdSerializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/RawKeyStdSerializer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.server;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.github.nmorel.gwtjackson.objectify.shared.RawKeyConstant;
+import com.google.appengine.api.datastore.Key;
+
+public class RawKeyStdSerializer extends StdSerializer<Key> {
+
+    public RawKeyStdSerializer() {
+        super( Key.class );
+    }
+
+    @Override
+    public void serialize( Key value, JsonGenerator jgen, SerializerProvider provider ) throws IOException {
+        jgen.writeStartObject();
+        boolean includeNull = Include.NON_NULL != provider.getConfig().getDefaultPropertyInclusion().getValueInclusion();
+        if ( value.getParent() != null || includeNull ) {
+            jgen.writeObjectField( RawKeyConstant.PARENT, value.getParent() );
+        }
+        if ( value.getKind() != null || includeNull ) {
+            jgen.writeStringField( RawKeyConstant.KIND, value.getKind() );
+        }
+        jgen.writeNumberField( RawKeyConstant.ID, value.getId() );
+        if ( value.getName() != null || includeNull ) {
+            jgen.writeStringField( RawKeyConstant.NAME, value.getName() );
+        }
+        jgen.writeEndObject();
+    }
+
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/RefJsonSerializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/RefJsonSerializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.server;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.googlecode.objectify.Ref;
+
+public class RefJsonSerializer extends JsonSerializer<Ref> {
+
+    private final RefStdSerializer refStdSerializer = new RefStdSerializer();
+
+    @Override
+    public void serialize( Ref value, JsonGenerator jgen, SerializerProvider provider ) throws IOException {
+        StringWriter writer = new StringWriter();
+        JsonGenerator jsonGenerator = jgen.getCodec().getFactory().createGenerator( writer );
+        refStdSerializer.serialize( value, jsonGenerator, provider );
+        jsonGenerator.close();
+        jgen.writeFieldName( writer.toString() );
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/RefStdDeserializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/RefStdDeserializer.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.server;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.github.nmorel.gwtjackson.objectify.shared.RefConstant;
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.Ref;
+import com.googlecode.objectify.impl.ref.DeadRef;
+
+public class RefStdDeserializer extends StdDeserializer<Ref<?>> implements ContextualDeserializer {
+
+    private final JavaType valueType;
+
+    public RefStdDeserializer() {
+        this( null );
+    }
+
+    public RefStdDeserializer( JavaType valueType ) {
+        super( Ref.class );
+        this.valueType = valueType;
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual( DeserializationContext ctxt, BeanProperty property ) throws JsonMappingException {
+        if ( ctxt.getContextualType() == null || ctxt.getContextualType().containedType( 0 ) == null ) {
+            throw JsonMappingException.from( ctxt, "Cannot deserialize Ref<T>. Cannot find the Generic Type T." );
+        }
+        return new RefStdDeserializer( ctxt.getContextualType().containedType( 0 ) );
+    }
+
+    @Override
+    public Ref<?> deserialize( JsonParser jp, DeserializationContext ctxt ) throws IOException {
+        if ( valueType == null ) {
+            throw JsonMappingException.from( ctxt, "valueType can't be null." );
+        }
+
+        JsonNode jsonNode = jp.readValueAsTree();
+
+        JsonParser keyJsonParser = jsonNode.get( RefConstant.KEY ).traverse();
+        keyJsonParser.setCodec( jp.getCodec() );
+        Key key = keyJsonParser.readValueAs( Key.class );
+
+        Object value = null;
+        if ( jsonNode.has( RefConstant.VALUE ) ) {
+            JsonParser valueJsonParser = jsonNode.get( RefConstant.VALUE ).traverse();
+            valueJsonParser.setCodec( jp.getCodec() );
+            value = valueJsonParser.readValueAs( valueType.getRawClass() );
+        }
+
+        return value != null ? new DeadRef( key, value ) : new DeadRef( key );
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/RefStdKeyDeserializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/RefStdKeyDeserializer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.server;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+import com.fasterxml.jackson.databind.deser.ContextualKeyDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdKeyDeserializer;
+import com.googlecode.objectify.Ref;
+
+public class RefStdKeyDeserializer extends StdKeyDeserializer implements ContextualKeyDeserializer {
+
+    private final JavaType valueType;
+
+    public RefStdKeyDeserializer() {
+        this( null );
+    }
+
+    public RefStdKeyDeserializer( JavaType valueType ) {
+        super( StdKeyDeserializer.TYPE_CLASS, Ref.class );
+        this.valueType = valueType;
+    }
+
+    @Override
+    public Object deserializeKey( String key, DeserializationContext ctxt ) throws IOException {
+        JsonParser jsonParser = ctxt.getParser().getCodec().getFactory().createParser( key );
+        return new RefStdDeserializer( valueType ).deserialize( jsonParser, ctxt );
+    }
+
+    @Override
+    public KeyDeserializer createContextual( DeserializationContext ctxt, BeanProperty property ) throws JsonMappingException {
+        if ( ctxt.getContextualType() == null || ctxt.getContextualType().containedType( 0 ) == null || ctxt.getContextualType().containedType( 0 ).containedType( 0 ) == null ) {
+            throw JsonMappingException.from( ctxt, "Cannot deserialize Ref<T>. Cannot find the Generic Type T." );
+        }
+        return new RefStdKeyDeserializer( ctxt.getContextualType().containedType( 0 ).containedType( 0 ) );
+    }
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/RefStdSerializer.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/server/RefStdSerializer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.server;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.github.nmorel.gwtjackson.objectify.shared.RefConstant;
+import com.googlecode.objectify.Ref;
+
+public class RefStdSerializer extends StdSerializer<Ref> {
+
+    public RefStdSerializer() {
+        super( Ref.class );
+    }
+
+    @Override
+    public void serialize( Ref ref, JsonGenerator jgen, SerializerProvider provider ) throws IOException {
+        jgen.writeStartObject();
+        boolean includeNull = Include.NON_NULL != provider.getConfig().getDefaultPropertyInclusion().getValueInclusion();
+        if ( ref.key() != null || includeNull ) {
+            jgen.writeObjectField( RefConstant.KEY, ref.key() );
+        }
+        if ( ref.getValue() != null || includeNull ) {
+            jgen.writeObjectField( RefConstant.VALUE, ref.getValue() );
+        }
+        jgen.writeEndObject();
+    }
+
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/shared/KeyConstant.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/shared/KeyConstant.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.shared;
+
+public class KeyConstant {
+
+    public static final String RAW = "raw";
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/shared/RawKeyConstant.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/shared/RawKeyConstant.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.shared;
+
+public class RawKeyConstant {
+
+    public static final String PARENT = "parent";
+
+    public static final String NAME = "name";
+
+    public static final String KIND = "kind";
+
+    public static final String ID = "id";
+}

--- a/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/shared/RefConstant.java
+++ b/extensions/objectify/src/main/java/com/github/nmorel/gwtjackson/objectify/shared/RefConstant.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.objectify.shared;
+
+public class RefConstant {
+
+    public static final String KEY = "key";
+
+    public static final String VALUE = "value";
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/GwtJacksonObjectify.gwt.xml
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/GwtJacksonObjectify.gwt.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<module>
+  <inherits name="com.github.nmorel.gwtjackson.GwtJackson" />
+
+  <extend-configuration-property name="gwtjackson.configuration.extension"
+                                 value="com.github.nmorel.gwtjackson.objectify.rebind.ObjectifyConfiguration" />
+
+  <source path="client" />
+  <source path="shared" />
+  <super-source path="super" />
+</module>

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/AppIdNamespace.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/AppIdNamespace.java
@@ -1,0 +1,143 @@
+// Copyright 2009 Google Inc. All Rights Reserved.
+
+package com.google.appengine.api.datastore;
+
+import java.io.Serializable;
+
+import com.google.apphosting.api.NamespaceResources;
+
+/**
+ * Abstraction for a "mangled" AppId.  A mangled AppId is a combination
+ * of the application id and the name_space which this class will
+ * manage.
+ */
+class AppIdNamespace implements Serializable, Comparable<AppIdNamespace> {
+
+    private final String appId;
+
+    private final String namespace;
+
+    private static final String BAD_APP_ID_MESSAGE =
+            "appId or namespace cannot contain '" + NamespaceResources.NAMESPACE_SEPARATOR + "'";
+
+    /**
+     * Constructs an {@link AppIdNamespace} given {@code #appId} and {@code #namespace}.
+     */
+    public AppIdNamespace( String appId, String namespace ) {
+        if ( appId == null || namespace == null ) {
+            throw new IllegalArgumentException( "appId or namespace may not be null" );
+        }
+        if ( appId.indexOf( NamespaceResources.NAMESPACE_SEPARATOR ) != -1 ||
+                namespace.indexOf( NamespaceResources.NAMESPACE_SEPARATOR ) != -1 ) {
+            throw new IllegalArgumentException( BAD_APP_ID_MESSAGE );
+        }
+        this.appId = appId;
+        this.namespace = namespace;
+    }
+
+    /**
+     * Converts an encoded appId/namespace to {@link AppIdNamespace}.
+     * <p>
+     * <p>Only one form of an appId/namespace pair will be allowed. i.e. "app!"
+     * is an illegal form and must be encoded as "app".
+     * <p>
+     * <p>An appId/namespace pair may contain at most one "!" character.
+     *
+     * @param encodedAppIdNamespace The encoded application Id/namespace string.
+     */
+    public static AppIdNamespace parseEncodedAppIdNamespace( String encodedAppIdNamespace ) {
+        if ( encodedAppIdNamespace == null ) {
+            throw new IllegalArgumentException( "appIdNamespaceString may not be null" );
+        }
+        int index = encodedAppIdNamespace.indexOf( NamespaceResources.NAMESPACE_SEPARATOR );
+        if ( index == -1 ) {
+            return new AppIdNamespace( encodedAppIdNamespace, "" );
+        }
+        String appId = encodedAppIdNamespace.substring( 0, index );
+        String namespace = encodedAppIdNamespace.substring( index + 1 );
+        if ( namespace.length() == 0 ) {
+            throw new IllegalArgumentException(
+                    "encodedAppIdNamespace with empty namespace may not contain a '" +
+                            NamespaceResources.NAMESPACE_SEPARATOR + "'" );
+        }
+        return new AppIdNamespace( appId, namespace );
+    }
+
+    /**
+     * Perform a "lexical" comparison to {@code other} {@link AppIdNamespace}.
+     *
+     * @return See {@link String#compareTo(String)}.
+     */
+    @Override
+    public int compareTo( AppIdNamespace other ) {
+        int appidCompare = appId.compareTo( other.appId );
+        if ( appidCompare == 0 ) {
+            return namespace.compareTo( other.namespace );
+        }
+        return appidCompare;
+    }
+
+    public String getAppId() {
+        return appId;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    /**
+     * Returns an "encoded" appId/namespace string.
+     * <p>
+     * <p>Note: If the {@link #namespace} is empty, the return value is exactly the {@link #appId}.
+     */
+    public String toEncodedString() {
+        if ( namespace.equals( "" ) ) {
+            return appId;
+        } else {
+            return appId + NamespaceResources.NAMESPACE_SEPARATOR + namespace;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((appId == null) ? 0 : appId.hashCode());
+        result = prime * result + ((namespace == null) ? 0 : namespace.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals( Object obj ) {
+        if ( this == obj ) {
+            return true;
+        }
+        if ( obj == null ) {
+            return false;
+        }
+        if ( getClass() != obj.getClass() ) {
+            return false;
+        }
+        AppIdNamespace other = (AppIdNamespace) obj;
+        if ( appId == null ) {
+            if ( other.appId != null ) {
+                return false;
+            }
+        } else if ( !appId.equals( other.appId ) ) {
+            return false;
+        }
+        if ( namespace == null ) {
+            if ( other.namespace != null ) {
+                return false;
+            }
+        } else if ( !namespace.equals( other.namespace ) ) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return toEncodedString();
+    }
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/Blob.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/Blob.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2007 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.appengine.api.datastore;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * {@code Blob} contains an array of bytes.  This byte array can be no bigger
+ * than 1MB.  To store files, particularly files larger than this 1MB limit,
+ * look at the Blobstore API.
+ */
+public final class Blob implements Serializable {
+
+    private static final long serialVersionUID = 6210713401925622518L;
+
+    private byte[] bytes;
+
+    /**
+     * Construct a new {@code Blob} with the specified bytes.  Since
+     * {@code Blobs} can be quite large we do not perform a defensive copy of the
+     * provided byte array.  It is the programmer's responsibility to avoid
+     * making changes to this array once the {@code Blob} has been constructed.
+     */
+    public Blob( byte[] bytes ) {
+        this.bytes = bytes;
+    }
+
+    /**
+     * This constructor exists for frameworks (e.g. Google Web Toolkit)
+     * that require it for serialization purposes.  It should not be
+     * called explicitly.
+     */
+    @SuppressWarnings( "unused" )
+    private Blob() {
+    }
+
+    /**
+     * Return the bytes stored in this {@code Blob}.
+     */
+    public byte[] getBytes() {
+        return bytes;
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode( bytes );
+    }
+
+    /**
+     * Two {@code Blob} objects are considered equal if their contained
+     * bytes match exactly.
+     */
+    @Override
+    public boolean equals( Object object ) {
+        if ( object instanceof Blob ) {
+            Blob key = (Blob) object;
+            return Arrays.equals( bytes, key.bytes );
+        }
+        return false;
+    }
+
+    /**
+     * Simply prints the number of bytes contained in this {@code Blob}.
+     */
+    @Override
+    public String toString() {
+        return "<Blob: " + bytes.length + " bytes>";
+    }
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/Category.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/Category.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2009 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.appengine.api.datastore;
+
+import java.io.Serializable;
+
+/**
+ * A tag, ie a descriptive word or phrase. Entities may be tagged by users,
+ * and later returned by a queries for that tag. Tags can also be used for
+ * ranking results (frequency), photo captions, clustering, activity, etc.
+ *
+ * @see <a href="http://www.zeldman.com/daily/0405d.shtml">Jeffrey Zeldmans blog post</a>
+ * on tag clouds for a more in-depth description.
+ */
+public final class Category implements Serializable, Comparable<Category> {
+
+    public static final long serialVersionUID = 8556134984576082397L;
+
+    private String category;
+
+    public Category( String category ) {
+        if ( category == null ) {
+            throw new NullPointerException( "category must not be null" );
+        }
+        this.category = category;
+    }
+
+    /**
+     * This constructor exists for frameworks (e.g. Google Web Toolkit)
+     * that require it for serialization purposes.  It should not be
+     * called explicitly.
+     */
+    @SuppressWarnings( "unused" )
+    private Category() {
+        this.category = null;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    @Override
+    public int compareTo( Category o ) {
+        return category.compareTo( o.category );
+    }
+
+    @Override
+    public boolean equals( Object o ) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        Category category1 = (Category) o;
+
+        if ( !category.equals( category1.category ) ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return category.hashCode();
+    }
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/Cursor.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/Cursor.java
@@ -1,0 +1,58 @@
+package com.google.appengine.api.datastore;
+
+import java.io.Serializable;
+
+/**
+ * GWT emulation class, much different from the official source code because it only wraps the websafestring.
+ * Will not have the same hashCode() value as the non-emulated version. This class will not have the same
+ * toString() value as the non-emulated version.
+ */
+@SuppressWarnings( "serial" )
+public final class Cursor implements Serializable {
+
+    private String webString;
+
+    public Cursor( String webString ) {
+        this.webString = webString;
+    }
+
+    public String toWebSafeString() {
+        return webString;
+    }
+
+    public static Cursor fromWebSafeString( String encodedCursor ) {
+        if ( encodedCursor == null ) {
+            throw new NullPointerException( "encodedCursor must not be null" );
+        }
+
+        return new Cursor( encodedCursor );
+    }
+
+    @Override
+    public boolean equals( Object o ) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        Cursor cursor = (Cursor) o;
+
+        if ( !webString.equals( cursor.webString ) ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return webString.hashCode();
+    }
+
+    public String toString() {
+        return webString;
+    }
+
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/DataTypeUtils.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/DataTypeUtils.java
@@ -1,0 +1,13 @@
+package com.google.appengine.api.datastore;
+
+/**
+ * GWT emulation class.
+ */
+public class DataTypeUtils {
+
+    public static final int MAX_STRING_PROPERTY_LENGTH = 500;
+
+    public static final int MAX_SHORT_BLOB_PROPERTY_LENGTH = 500;
+
+    public static final int MAX_LINK_PROPERTY_LENGTH = 2038;
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/Email.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/Email.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2009 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.appengine.api.datastore;
+
+import java.io.Serializable;
+
+/**
+ * An e-mail address datatype. Makes no attempt at validation.
+ *
+ * @see <a href="http://tools.ietf.org/html/rfc2822">RFC 2822</a>
+ * for the e-mail address specification.
+ */
+public final class Email implements Serializable, Comparable<Email> {
+
+    static final long serialVersionUID = -4807513785819575482L;
+
+    private String email;
+
+    public Email( String email ) {
+        if ( email == null ) {
+            throw new NullPointerException( "email must not be null" );
+        }
+        this.email = email;
+    }
+
+    /**
+     * This constructor exists for frameworks (e.g. Google Web Toolkit)
+     * that require it for serialization purposes.  It should not be
+     * called explicitly.
+     */
+    @SuppressWarnings( "unused" )
+    private Email() {
+        this.email = null;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    @Override
+    public int compareTo( Email e ) {
+        return email.compareTo( e.email );
+    }
+
+    @Override
+    public boolean equals( Object o ) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        Email email1 = (Email) o;
+
+        if ( !email.equals( email1.email ) ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return email.hashCode();
+    }
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/EntityNotFoundException.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/EntityNotFoundException.java
@@ -1,0 +1,21 @@
+// Copyright 2007 Google Inc. All rights reserved.
+
+package com.google.appengine.api.datastore;
+
+/**
+ * {@code EntityNotFoundException} is thrown when no {@code Entity}
+ * with the specified {@code Key} could be found.
+ */
+public class EntityNotFoundException extends Exception {
+
+    private final Key key;
+
+    public EntityNotFoundException( Key key ) {
+        super( "No entity was found matching the key: " + key );
+        this.key = key;
+    }
+
+    public Key getKey() {
+        return key;
+    }
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/GeoPt.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/GeoPt.java
@@ -1,0 +1,106 @@
+// Copyright 2008 Google Inc. All Rights Reserved.
+
+package com.google.appengine.api.datastore;
+
+import java.io.Serializable;
+
+/**
+ * A geographical point, specified by float latitude and longitude coordinates.
+ * Often used to integrate with mapping sites like Google Maps.
+ */
+public final class GeoPt implements Serializable, Comparable<GeoPt> {
+
+    public static final long serialVersionUID = 349808987517153697L;
+
+    private float latitude;
+
+    private float longitude;
+
+    /**
+     * Constructs a {@code GeoPt}.
+     *
+     * @param latitude The latitude. Must be between -90 and 90 (inclusive).
+     * @param longitude The longitude. Must be between -180 and 180 (inclusive).
+     *
+     * @throws IllegalArgumentException If {@code latitude} or {@code longitude} is outside the legal
+     * range.
+     */
+    public GeoPt( float latitude, float longitude ) {
+        if ( Math.abs( latitude ) > 90 ) {
+            throw new IllegalArgumentException( "Latitude must be between -90 and 90 (inclusive)." );
+        }
+
+        if ( Math.abs( longitude ) > 180 ) {
+            throw new IllegalArgumentException( "Longitude must be between -180 and 180." );
+        }
+
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    /**
+     * This constructor exists for frameworks (e.g. Google Web Toolkit) that
+     * require it for serialization purposes. It should not be called
+     * explicitly.
+     */
+    @SuppressWarnings( "unused" )
+    private GeoPt() {
+        this( 0, 0 );
+    }
+
+    public float getLatitude() {
+        return latitude;
+    }
+
+    public float getLongitude() {
+        return longitude;
+    }
+
+    /**
+     * Sort first by latitude, then by longitude
+     */
+    @Override
+    public int compareTo( GeoPt o ) {
+        int latResult = ((Float) latitude).compareTo( o.latitude );
+        if ( latResult != 0 ) {
+            return latResult;
+        }
+        return ((Float) longitude).compareTo( o.longitude );
+    }
+
+    @Override
+    public boolean equals( Object o ) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        GeoPt geoPt = (GeoPt) o;
+
+        if ( Float.compare( geoPt.latitude, latitude ) != 0 ) {
+            return false;
+        }
+        if ( Float.compare( geoPt.longitude, longitude ) != 0 ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result;
+        result = (latitude != +0.0f ? Float.floatToIntBits( latitude ) : 0);
+        result = 31 * result + (longitude != +0.0f ? Float.floatToIntBits( longitude ) : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        // String.format() is not part of GWT's JRE emulation
+        //return String.format("%f,%f", latitude, longitude);
+        return "GeoPt(" + latitude + ", " + longitude + ")";
+    }
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/IMHandle.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/IMHandle.java
@@ -1,0 +1,154 @@
+// Copyright 2009 Google Inc. All Rights Reserved.
+package com.google.appengine.api.datastore;
+
+import java.io.Serializable;
+import java.net.URL;
+
+/**
+ * An instant messaging handle. Includes both an address and its protocol. The
+ * protocol value is either a standard IM scheme (legal scheme values are
+ * defined by {@link Scheme} or a URL identifying the IM network for the
+ * protocol (e.g. http://aim.com/).
+ */
+public final class IMHandle implements Serializable, Comparable<IMHandle> {
+
+    public static final long serialVersionUID = 6963426833434504530L;
+
+    /**
+     * Supported IM schemes.
+     */
+    public enum Scheme {
+        sip, unknown, xmpp
+    }
+
+    private String protocol;
+
+    private String address;
+
+    public IMHandle( Scheme scheme, String address ) {
+        if ( scheme == null ) {
+            throw new NullPointerException( "scheme must not be null" );
+        }
+        validateAddress( address );
+        this.protocol = scheme.name();
+        this.address = address;
+    }
+
+    // URL is not part of GWT JRE emulation
+    //
+    //	public IMHandle(URL network, String address) {
+    //		if (network == null) {
+    //			throw new NullPointerException("network must not be null");
+    //		}
+    //		validateAddress(address);
+    //		this.protocol = network.toString();
+    //		this.address = address;
+    //	}
+
+    /**
+     * This constructor exists for frameworks (e.g. Google Web Toolkit) that
+     * require it for serialization purposes. It should not be called
+     * explicitly.
+     */
+    @SuppressWarnings( "unused" )
+    private IMHandle() {
+        this.protocol = null;
+        this.address = null;
+    }
+
+    /**
+     * Constructs an {@code IMHandle} from a string in the format returned by
+     * {@link #toDatastoreString()}.
+     *
+     * @throws IllegalArgumentException If the provided string does not match the format returned by
+     * {@link #toDatastoreString()} or the first component of the
+     * string is not a valid {@link Scheme} and is not a valid
+     * {@link URL}.
+     */
+    // URL and MalformedURLException are not part of GWT JRE emulation
+    //
+    //	static IMHandle fromDatastoreString(String datastoreString) {
+    //		if (datastoreString == null) {
+    //			throw new NullPointerException("datastoreString must not be null");
+    //		}
+    //		String[] split = datastoreString.split(" ", 2);
+    //		if (split.length != 2) {
+    //			throw new IllegalArgumentException("Datastore string must have at least one space: " + datastoreString);
+    //		}
+    //		try {
+    //			return new IMHandle(IMHandle.Scheme.valueOf(split[0]), split[1]);
+    //		} catch (IllegalArgumentException iae) {
+    //			try {
+    //				return new IMHandle(new URL(split[0]), split[1]);
+    //			} catch (MalformedURLException e) {
+    //				throw new IllegalArgumentException("String in datastore could not be parsed into a valid IMHandle.  "
+    //						+ "Protocol must either be a valid scheme or url: " + split[0]);
+    //			}
+    //		}
+    //	}
+    private static void validateAddress( String address ) {
+        if ( address == null ) {
+            throw new NullPointerException( "address must not be null" );
+        }
+    }
+
+    /**
+     * The datastore representation of the {@code IMHandle}. This must not
+     * change.
+     */
+    String toDatastoreString() {
+        // GWT JRE emulation missing
+        //return String.format("%s %s", protocol, address);
+        return protocol + " " + address;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    @Override
+    public boolean equals( Object o ) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        IMHandle imHandle = (IMHandle) o;
+
+        if ( !address.equals( imHandle.address ) ) {
+            return false;
+        }
+        if ( !protocol.equals( imHandle.protocol ) ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result;
+        result = protocol.hashCode();
+        result = 31 * result + address.hashCode();
+        return result;
+    }
+
+    /**
+     * Sorts first by protocol, then by address.
+     */
+    @Override
+    public int compareTo( IMHandle o ) {
+        return toDatastoreString().compareTo( o.toDatastoreString() );
+    }
+
+    @Override
+    public String toString() {
+        return toDatastoreString();
+    }
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/Key.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/Key.java
@@ -1,0 +1,204 @@
+package com.google.appengine.api.datastore;
+
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.LinkedList;
+
+/**
+ * GWT emulation class. Will not have the same hashCode() value as the non-emulated version.
+ * This class does not transmit the appId, and when deserializing on the server side, it just uses
+ * the appId of the environment.
+ * <p>
+ * Does not take applicationID of parents/children into consideration wrt Comparable, assumes they are both the same.
+ */
+public final class Key implements Serializable, Comparable<Key> {
+
+    static final long serialVersionUID = -448150158203091507L;
+
+    private Key parentKey;
+
+    private String kind;
+
+    //private String appId;
+    private long id;
+
+    private String name;
+    //private transient AppIdNamespace appIdNamespace;
+
+    @SuppressWarnings( "unused" )
+    private Key() {
+        parentKey = null;
+        kind = null;
+        id = 0;
+        name = null;
+    }
+
+    Key( String kind, String name ) {
+        this( kind, null, name );
+    }
+
+    Key( String kind, Key parentKey ) {
+        this( kind, parentKey, 0 );
+    }
+
+    Key( String kind, Key parentKey, long id ) {
+        this( kind, parentKey, id, null );
+    }
+
+    Key( String kind, Key parentKey, String name ) {
+        this( kind, parentKey, 0, name );
+    }
+
+    Key( String kind, Key parentKey, long id, String name ) {
+        if ( kind == null || kind.length() == 0 ) {
+            throw new IllegalArgumentException( "No kind specified." );
+        }
+        if ( name != null ) {
+            if ( name.length() == 0 ) {
+                throw new IllegalArgumentException( "Name may not be empty." );
+            }
+            if ( id != 0 ) {
+                throw new IllegalArgumentException( "Id and name may not both be specified at once." );
+            }
+        }
+        this.name = name;
+        this.id = id;
+        this.parentKey = parentKey;
+        this.kind = kind;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public Key getParent() {
+        return parentKey;
+    }
+
+    @Override
+    public boolean equals( Object o ) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        Key key = (Key) o;
+
+        if ( id != key.id ) {
+            return false;
+        }
+        if ( !kind.equals( key.kind ) ) {
+            return false;
+        }
+        if ( name != null ? !name.equals( key.name ) : key.name != null ) {
+            return false;
+        }
+        if ( parentKey != null ? !parentKey.equals( key.parentKey ) : key.parentKey != null ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = parentKey != null ? parentKey.hashCode() : 0;
+        result = 31 * result + kind.hashCode();
+        result = 31 * result + (int) (id ^ (id >>> 32));
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        return result;
+    }
+
+    public String toString() {
+        StringBuilder buffer = new StringBuilder();
+        appendToString( buffer );
+        return buffer.toString();
+    }
+
+    private void appendToString( StringBuilder buffer ) {
+        if ( parentKey != null ) {
+            parentKey.appendToString( buffer );
+            buffer.append( "/" );
+        }
+        buffer.append( kind );
+        buffer.append( "(" );
+        if ( name != null ) {
+            buffer.append( '"' ).append( name ).append( '"' );
+        } else {
+            buffer.append( id );
+        }
+        buffer.append( ")" );
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Key getChild( String kind, long id ) {
+        return new Key( kind, this, id );
+    }
+
+    public Key getChild( String kind, String name ) {
+        return new Key( kind, this, name );
+    }
+
+    private static Iterator<Key> getPathIterator( Key key ) {
+        LinkedList<Key> stack = new LinkedList<Key>();
+        do {
+            stack.addFirst( key );
+            key = key.getParent();
+        } while ( key != null );
+
+        return stack.iterator();
+    }
+
+    public int compareTo( Key other ) {
+        if ( this == other ) {
+            return 0;
+        }
+        Iterator<Key> thisPath = getPathIterator( this );
+        Iterator<Key> otherPath = getPathIterator( other );
+        while ( thisPath.hasNext() ) {
+            Key thisKey = (Key) thisPath.next();
+            if ( otherPath.hasNext() ) {
+                Key otherKey = (Key) otherPath.next();
+                int result = compareToInternal( thisKey, otherKey );
+                if ( result != 0 ) {
+                    return result;
+                }
+            } else {
+                return 1;
+            }
+        }
+        return otherPath.hasNext() ? -1 : 0;
+    }
+
+    private static int compareToInternal( Key thisKey, Key otherKey ) {
+        if ( thisKey == otherKey ) {
+            return 0;
+        }
+        int result = thisKey.getKind().compareTo( otherKey.getKind() );
+        if ( result != 0 ) {
+            return result;
+        }
+        if ( thisKey.getId() != 0 ) {
+            if ( otherKey.getId() == 0 ) {
+                return -1;
+            } else {
+                return Long.valueOf( thisKey.getId() ).compareTo( Long.valueOf( otherKey.getId() ) );
+            }
+        }
+        if ( otherKey.getId() != 0 ) {
+            return 1;
+        } else {
+            return thisKey.getName().compareTo( otherKey.getName() );
+        }
+    }
+}
+

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/KeyFactory.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/KeyFactory.java
@@ -1,0 +1,67 @@
+package com.google.appengine.api.datastore;
+
+/**
+ * GWT emulation class, with most of the methods from KeyFactory.
+ * Does not support the keyToString()/stringToKey() methods.
+ */
+public class KeyFactory {
+
+    public static final class Builder {
+
+        public Builder addChild( String kind, String name ) {
+            current = KeyFactory.createKey( current, kind, name );
+            return this;
+        }
+
+        public Builder addChild( String kind, long id ) {
+            current = KeyFactory.createKey( current, kind, id );
+            return this;
+        }
+
+        public Key getKey() {
+            return current;
+        }
+
+        private Key current;
+
+        public Builder( String kind, String name ) {
+            current = KeyFactory.createKey( null, kind, name );
+        }
+
+        public Builder( String kind, long id ) {
+            current = KeyFactory.createKey( null, kind, id );
+        }
+
+        public Builder( Key key ) {
+            current = key;
+        }
+    }
+
+    public static Key createKey( String kind, long id ) {
+        return createKey( null, kind, id );
+    }
+
+    public static Key createKey( Key parent, String kind, long id ) {
+        if ( id == 0L ) {
+            throw new IllegalArgumentException( "id cannot be zero" );
+        } else {
+            return new Key( kind, parent, id );
+        }
+    }
+
+    public static Key createKey( String kind, String name ) {
+        return createKey( null, kind, name );
+    }
+
+    public static Key createKey( Key parent, String kind, String name ) {
+        if ( name == null || name.length() == 0 ) {
+            throw new IllegalArgumentException( "name cannot be null or empty" );
+        } else {
+            return new Key( kind, parent, name );
+        }
+    }
+
+    private KeyFactory() {
+    }
+
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/Link.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/Link.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2008 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.appengine.api.datastore;
+
+import java.io.Serializable;
+
+/**
+ * A {@code Link} is a URL of limited length.
+ * <p>
+ * In addition to adding the meaning of {@code URL} onto a String, a {@code Link}
+ * can also be longer than a Text value, with a limit of 2038 characters.
+ */
+public final class Link implements Serializable, Comparable<Link> {
+
+    public static final long serialVersionUID = 731239796613544443L;
+
+    private String value;
+
+    /**
+     * This constructor exists for frameworks (e.g. Google Web Toolkit)
+     * that require it for serialization purposes.  It should not be
+     * called explicitly.
+     */
+    @SuppressWarnings( "unused" )
+    private Link() {
+        value = null;
+    }
+
+    /**
+     * Constructs a new {@code Link} object with the specified value.
+     * This object cannot be modified after construction.
+     */
+    public Link( String value ) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the value of this {@code Link}.
+     */
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    /**
+     * Two {@code Link} objects are considered equal if their content
+     * strings match exactly.
+     */
+    @Override
+    public boolean equals( Object object ) {
+        if ( object instanceof Link ) {
+            Link key = (Link) object;
+            return value.equals( key.value );
+        }
+        return false;
+    }
+
+    /**
+     * Returns the entire text of this {@code Link}.
+     */
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public int compareTo( Link l ) {
+        return value.compareTo( l.value );
+    }
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/PhoneNumber.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/PhoneNumber.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2009 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.appengine.api.datastore;
+
+import java.io.Serializable;
+
+/**
+ * A human-readable phone number.  No validation is performed because phone
+ * numbers have many different formats - local, long distance, domestic,
+ * international, internal extension, TTY, VOIP, SMS, and alternative networks
+ * like Skype, XFire and Roger Wilco.  They all have their own numbering and
+ * addressing formats.
+ */
+public final class PhoneNumber implements Serializable, Comparable<PhoneNumber> {
+
+    public static final long serialVersionUID = -8968032543663409348L;
+
+    private String number;
+
+    public PhoneNumber( String number ) {
+        if ( number == null ) {
+            throw new NullPointerException( "number must not be null" );
+        }
+        this.number = number;
+    }
+
+    /**
+     * This constructor exists for frameworks (e.g. Google Web Toolkit)
+     * that require it for serialization purposes.  It should not be
+     * called explicitly.
+     */
+    @SuppressWarnings( "unused" )
+    private PhoneNumber() {
+        number = null;
+    }
+
+    public String getNumber() {
+        return number;
+    }
+
+    @Override
+    public boolean equals( Object o ) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        PhoneNumber that = (PhoneNumber) o;
+
+        if ( !number.equals( that.number ) ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return number.hashCode();
+    }
+
+    @Override
+    public int compareTo( PhoneNumber o ) {
+        return number.compareTo( o.number );
+    }
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/PostalAddress.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/PostalAddress.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2009 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.appengine.api.datastore;
+
+import java.io.Serializable;
+
+/**
+ * A human-readable mailing address.  Mailing address formats vary widely so
+ * no validation is performed.
+ */
+public final class PostalAddress implements Serializable, Comparable<PostalAddress> {
+
+    public static final long serialVersionUID = -1090628591187239495L;
+
+    private String address;
+
+    public PostalAddress( String address ) {
+        if ( address == null ) {
+            throw new NullPointerException( "address must not be null" );
+        }
+        this.address = address;
+    }
+
+    /**
+     * This constructor exists for frameworks (e.g. Google Web Toolkit)
+     * that require it for serialization purposes.  It should not be
+     * called explicitly.
+     */
+    @SuppressWarnings( "unused" )
+    private PostalAddress() {
+        address = null;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    @Override
+    public boolean equals( Object o ) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        PostalAddress that = (PostalAddress) o;
+
+        if ( !address.equals( that.address ) ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return address.hashCode();
+    }
+
+    @Override
+    public int compareTo( PostalAddress o ) {
+        return address.compareTo( o.address );
+    }
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/Rating.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/Rating.java
@@ -1,0 +1,83 @@
+// Copyright 2009 Google Inc. All Rights Reserved.
+package com.google.appengine.api.datastore;
+
+import java.io.Serializable;
+
+/**
+ * A user-provided integer rating for a piece of content. Normalized to a 0-100
+ * scale.
+ */
+public final class Rating implements Serializable, Comparable<Rating> {
+
+    public static final long serialVersionUID = 362898405551261187L;
+
+    /**
+     * The minimum legal value for a rating.
+     */
+    public static final int MIN_VALUE = 0;
+
+    /**
+     * The maximum legal value for a rating.
+     */
+    public static final int MAX_VALUE = 100;
+
+    private int rating;
+
+    /**
+     * @throws IllegalArgumentException If {@code rating} is smaller than {@link #MIN_VALUE} or
+     * greater than {@link #MAX_VALUE}
+     */
+    public Rating( int rating ) {
+        if ( rating < MIN_VALUE || rating > MAX_VALUE ) {
+            // String.format() not part of GWT JRE emulation
+            //			throw new IllegalArgumentException(String.format(
+            //					"rating must be no smaller than %d and no greater than %d (received %d)", MIN_VALUE, MAX_VALUE,
+            //					rating));
+            throw new IllegalArgumentException(
+                    "rating must be no smaller than " + MIN_VALUE + " and no greater than " + MAX_VALUE + " (received " + rating + ")" );
+        }
+        this.rating = rating;
+    }
+
+    /**
+     * This constructor exists for frameworks (e.g. Google Web Toolkit) that
+     * require it for serialization purposes. It should not be called
+     * explicitly.
+     */
+    @SuppressWarnings( "unused" )
+    private Rating() {
+        this( 0 );
+    }
+
+    public int getRating() {
+        return rating;
+    }
+
+    @Override
+    public boolean equals( Object o ) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        Rating rating1 = (Rating) o;
+
+        if ( rating != rating1.rating ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return rating;
+    }
+
+    @Override
+    public int compareTo( Rating o ) {
+        return Integer.valueOf( rating ).compareTo( o.rating );
+    }
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/ShortBlob.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/ShortBlob.java
@@ -1,0 +1,45 @@
+package com.google.appengine.api.datastore;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * GWT emulation class, leaves off some references to not-gwt-safe code. In particular, the Comparable
+ * interface implementation.
+ */
+@SuppressWarnings( "serial" )
+public class ShortBlob implements Serializable {
+
+    private byte bytes[];
+
+    @SuppressWarnings( "unused" )
+    private ShortBlob() {
+        bytes = null;
+    }
+
+    public ShortBlob( byte bytes[] ) {
+        this.bytes = new byte[bytes.length];
+        System.arraycopy( bytes, 0, this.bytes, 0, bytes.length );
+    }
+
+    public byte[] getBytes() {
+        return bytes;
+    }
+
+    public int hashCode() {
+        return Arrays.hashCode( bytes );
+    }
+
+    public boolean equals( Object object ) {
+        if ( object instanceof ShortBlob ) {
+            ShortBlob other = (ShortBlob) object;
+            return Arrays.equals( bytes, other.bytes );
+        } else {
+            return false;
+        }
+    }
+
+    public String toString() {
+        return (new StringBuilder()).append( "<ShortBlob: " ).append( bytes.length ).append( " bytes>" ).toString();
+    }
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/Text.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/datastore/Text.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2007 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.appengine.api.datastore;
+
+import java.io.Serializable;
+
+/**
+ * {@code Text} wraps around a string of unlimited size.
+ * <p>
+ * Ordinary Java strings stored as properties in {@code Entity}
+ * objects are limited to 500 characters.  However, {@code Text}
+ * objects can also be stored in properties, and are unlimited in
+ * size.  However, they will not be indexed for query purposes.
+ */
+public final class Text implements Serializable {
+
+    public static final long serialVersionUID = -8389037235415462280L;
+
+    private String value;
+
+    /**
+     * This constructor exists for frameworks (e.g. Google Web Toolkit)
+     * that require it for serialization purposes.  It should not be
+     * called explicitly.
+     */
+    @SuppressWarnings( "unused" )
+    private Text() {
+    }
+
+    /**
+     * Construct a new {@code Text} object with the specified value.
+     * This object cannot be modified after construction.
+     */
+    public Text( String value ) {
+        this.value = value;
+    }
+
+    /**
+     * Return the value of this {@code Text}.  Can be {@code null}.
+     */
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        if ( value == null ) {
+            return -1;
+        }
+        return value.hashCode();
+    }
+
+    /**
+     * Two {@code Text} objects are considered equal if their content
+     * strings match exactly.
+     */
+    @Override
+    public boolean equals( Object object ) {
+        if ( object instanceof Text ) {
+            Text key = (Text) object;
+            if ( value == null ) {
+                return key.value == null;
+            }
+            return value.equals( key.value );
+        }
+        return false;
+    }
+
+    /**
+     * Returns the first 70 characters of the underlying string.
+     */
+    @Override
+    public String toString() {
+        if ( value == null ) {
+            return "<Text: null>";
+        }
+        String text = value;
+        if ( text.length() > 70 ) {
+            text = text.substring( 0, 70 ) + "...";
+        }
+        return "<Text: " + text + ">";
+    }
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/users/User.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/appengine/api/users/User.java
@@ -1,0 +1,87 @@
+package com.google.appengine.api.users;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * GWT emulation class.
+ */
+public class User implements Serializable, Comparable<User> {
+
+    static final long serialVersionUID = 8691571286358652288L;
+
+    private String email;
+
+    private String authDomain;
+
+    private String userId;
+
+    @SuppressWarnings( "unused" )
+    private User() {
+    }
+
+    public User( String email, String authDomain ) {
+        this( email, authDomain, null );
+    }
+
+    @JsonCreator
+    public User( @JsonProperty( "email" ) String email, @JsonProperty( "authDomain" ) String authDomain, @JsonProperty( "userId" ) String
+			userId ) {
+        if ( email == null ) {
+            throw new NullPointerException( "email must be specified" );
+        }
+        if ( authDomain == null ) {
+            throw new NullPointerException( "authDomain must be specified" );
+        } else {
+            this.email = email;
+            this.authDomain = authDomain;
+            this.userId = userId;
+            return;
+        }
+    }
+
+    public String getNickname() {
+        int indexOfDomain = email.indexOf( "@" + authDomain );
+        if ( indexOfDomain == -1 ) {
+            return email;
+        } else {
+            return email.substring( 0, indexOfDomain );
+        }
+    }
+
+    public String getAuthDomain() {
+        return authDomain;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String toString() {
+        return email;
+    }
+
+    public boolean equals( Object object ) {
+        if ( !(object instanceof User) ) {
+            return false;
+        } else {
+            User user = (User) object;
+            return user.email.equals( email ) && user.authDomain.equals( authDomain );
+        }
+    }
+
+    public int hashCode() {
+        return 17 * email.hashCode() + authDomain.hashCode();
+    }
+
+    public int compareTo( User user ) {
+        return email.compareTo( user.email );
+    }
+
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/apphosting/api/NamespaceResources.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/google/apphosting/api/NamespaceResources.java
@@ -1,0 +1,17 @@
+// Copyright 2009 Google Inc. All Rights Reserved.
+
+package com.google.apphosting.api;
+
+/**
+ * Reources for namespaces used by front end and back end.
+ */
+public final class NamespaceResources {
+
+    /**
+     * The separator character used to encode the appId/namespace pair.
+     */
+    public static final char NAMESPACE_SEPARATOR = '!';
+
+    private NamespaceResources() {
+    }
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/googlecode/objectify/Key.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/googlecode/objectify/Key.java
@@ -1,0 +1,272 @@
+package com.googlecode.objectify;
+
+import java.io.Serializable;
+
+import com.google.gwt.core.shared.GwtIncompatible;
+
+/**
+ * <p>A typesafe wrapper for the datastore Key object.</p>
+ *
+ * @author Jeff Schnitzer <jeff@infohazard.org>
+ * @author Scott Hernandez
+ */
+public class Key<T> implements Serializable, Comparable<Key<?>> {
+
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * Key.create(key) is easier to type than new Key<Blah>(key)
+     */
+    public static <T> Key<T> create( com.google.appengine.api.datastore.Key raw ) {
+        if ( raw == null ) {
+            throw new NullPointerException( "Cannot create a Key<?> from a null datastore Key" );
+        }
+
+        return new Key<T>( raw );
+    }
+
+    /**
+     * Key.create(Blah.class, id) is easier to type than new Key<Blah>(Blah.class, id)
+     */
+    @GwtIncompatible
+    public static <T> Key<T> create( Class<? extends T> kindClass, long id ) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Key.create(Blah.class, name) is easier to type than new Key<Blah>(Blah.class, name)
+     */
+    @GwtIncompatible
+    public static <T> Key<T> create( Class<? extends T> kindClass, String name ) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Key.create(parent, Blah.class, id) is easier to type than new Key<Blah>(parent, Blah.class, id)
+     */
+    @GwtIncompatible
+    public static <T> Key<T> create( Key<?> parent, Class<? extends T> kindClass, long id ) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Key.create(parent, Blah.class, name) is easier to type than new Key<Blah>(parent, Blah.class, name)
+     */
+    @GwtIncompatible
+    public static <T> Key<T> create( Key<?> parent, Class<? extends T> kindClass, String name ) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Key.create(webSafeString) is easier to type than new Key<Blah>(webSafeString)
+     */
+    @GwtIncompatible
+    public static <T> Key<T> create( String webSafeString ) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * This is an alias for Key.create(String) which exists for JAX-RS compliance.
+     */
+    @GwtIncompatible
+    public static <T> Key<T> valueOf( String webSafeString ) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Create a key from a registered POJO entity.
+     */
+    @GwtIncompatible
+    public static <T> Key<T> create( T pojo ) {
+        throw new UnsupportedOperationException();
+    }
+
+    /** */
+    protected com.google.appengine.api.datastore.Key raw;
+
+    /**
+     * Cache the instance of the parent wrapper to avoid unnecessary garbage
+     */
+    transient protected Key<?> parent;
+
+    /**
+     * For GWT serialization
+     */
+    private Key() {}
+
+    /**
+     * Wrap a raw Key
+     */
+    private Key( com.google.appengine.api.datastore.Key raw ) {
+        this.raw = raw;
+    }
+
+    /**
+     * Create a key with a long id
+     */
+    @GwtIncompatible
+    private Key( Class<? extends T> kindClass, long id ) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Create a key with a String name
+     */
+    @GwtIncompatible
+    private Key( Class<? extends T> kindClass, String name ) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Create a key with a parent and a long id
+     */
+    @GwtIncompatible
+    private Key( Key<?> parent, Class<? extends T> kindClass, long id ) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Create a key with a parent and a String name
+     */
+    @GwtIncompatible
+    private Key( Key<?> parent, Class<? extends T> kindClass, String name ) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Reconstitute a Key from a web safe string.  This can be generated with getString()/toWebSafeString()
+     * or KeyFactory.stringToKey().
+     */
+    @GwtIncompatible
+    private Key( String webSafe ) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @return the raw datastore version of this key
+     */
+    public com.google.appengine.api.datastore.Key getRaw() {
+        return this.raw;
+    }
+
+    /**
+     * @return the id associated with this key, or 0 if this key has a name.
+     */
+    public long getId() {
+        return this.raw.getId();
+    }
+
+    /**
+     * @return the name associated with this key, or null if this key has an id
+     */
+    public String getName() {
+        return this.raw.getName();
+    }
+
+    /**
+     * @return the low-level datastore kind associated with this Key
+     */
+    public String getKind() {
+        return this.raw.getKind();
+    }
+
+    /**
+     * @return the parent key, or null if there is no parent.  Note that
+     * the parent could potentially have any type.
+     */
+    @SuppressWarnings( "unchecked" )
+    public <V> Key<V> getParent() {
+        if ( this.parent == null && this.raw.getParent() != null ) {
+            this.parent = new Key<V>( this.raw.getParent() );
+        }
+
+        return (Key<V>) this.parent;
+    }
+
+    /**
+     * Gets the root of a parent graph of keys.  If a Key has no parent, it is the root.
+     *
+     * @return the topmost parent key, or this object itself if it is the root.
+     * Note that the root key could potentially have any type.
+     */
+    @SuppressWarnings( "unchecked" )
+    public <V> Key<V> getRoot() {
+        if ( this.getParent() == null ) {
+            return (Key<V>) this;
+        } else {
+            return this.getParent().getRoot();
+        }
+    }
+
+    /**
+     * A type-safe equivalence comparison
+     */
+    public boolean equivalent( Key<T> other ) {
+        return equals( other );
+    }
+
+    /**
+     * A type-safe equivalence comparison
+     */
+    public boolean equivalent( Ref<T> other ) {
+        return (other == null) ? false : equals( other.key() );
+    }
+
+    /**
+     * <p>Compares based on comparison of the raw key</p>
+     */
+    @Override
+    public int compareTo( Key<?> other ) {
+        return this.raw.compareTo( other.raw );
+    }
+
+    /** */
+    @Override
+    public boolean equals( Object obj ) {
+        if ( obj == null ) {
+            return false;
+        }
+
+        if ( !(obj instanceof Key<?>) ) {
+            return false;
+        }
+
+        return this.compareTo( (Key<?>) obj ) == 0;
+    }
+
+    /** */
+    @Override
+    public int hashCode() {
+        return this.raw.hashCode();
+    }
+
+    /**
+     * Creates a human-readable version of this key
+     */
+    @Override
+    public String toString() {
+        return "Key<?>(" + this.raw + ")";
+    }
+
+    /**
+     * Easy null-safe conversion of the raw key.
+     */
+    public static <V> Key<V> key( com.google.appengine.api.datastore.Key raw ) {
+        if ( raw == null ) {
+            return null;
+        } else {
+            return new Key<V>( raw );
+        }
+    }
+
+    /**
+     * Easy null-safe conversion of the typed key.
+     */
+    public static com.google.appengine.api.datastore.Key raw( Key<?> typed ) {
+        if ( typed == null ) {
+            return null;
+        } else {
+            return typed.getRaw();
+        }
+    }
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/googlecode/objectify/NotFoundException.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/googlecode/objectify/NotFoundException.java
@@ -1,0 +1,36 @@
+package com.googlecode.objectify;
+
+/**
+ * Exception thrown when a fetch for something could not be found.  This is associated with the
+ * getSafe() and keySafe() methods on Ref; if the item being sought in the Ref couldn't be found,
+ * this will be thrown.
+ */
+public class NotFoundException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /** */
+    private Key<?> key;
+
+    /**
+     * Thrown when there is no key context (eg, query.first() on an empty result set)
+     */
+    public NotFoundException() {
+        this( null );
+    }
+
+    /**
+     * Thrown when we at least know what we are looking for!
+     */
+    public NotFoundException( Key<?> key ) {
+        super( key == null ? "No entity was found" : "No entity was found matching the key: " + key );
+        this.key = key;
+    }
+
+    /**
+     * @return the key we are looking for, if known
+     */
+    public Key<?> getKey() {
+        return this.key;
+    }
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/googlecode/objectify/Ref.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/googlecode/objectify/Ref.java
@@ -1,0 +1,147 @@
+package com.googlecode.objectify;
+
+import java.io.Serializable;
+
+import com.google.gwt.core.shared.GwtIncompatible;
+import com.googlecode.objectify.impl.ref.LiveRef;
+
+/**
+ * <p>Ref<?> is a Key<?> which allows the entity value to be fetched directly.</p>
+ *
+ * <p>Note that the methods might or might not throw runtime exceptions related to datastore operations;
+ * ConcurrentModificationException, DatastoreTimeoutException, DatastoreFailureException, and DatastoreNeedIndexException.
+ * Some Refs hide datastore operations that could throw these exceptions.</p>
+ *
+ * @author Jeff Schnitzer <jeff@infohazard.org>
+ */
+abstract public class Ref<T> implements Serializable, Comparable<Ref<T>> {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The key associated with this ref
+     */
+    protected Key<T> key;
+
+    /**
+     * Key.create(Blah.class, id) is easier to type than new Key<Blah>(Blah.class, id)
+     */
+    @GwtIncompatible
+    public static <T> Ref<T> create( Key<T> key ) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates a Ref from a registered pojo entity
+     */
+    @GwtIncompatible
+    public static <T> Ref<T> create( T value ) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * For GWT serialization
+     */
+    protected Ref() {}
+
+    /**
+     * Create a Ref based on the key, with the specified session
+     */
+    public Ref( Key<T> key ) {
+        if (key == null)
+            throw new NullPointerException("Cannot create a Ref for a null key");
+
+        this.key = key;
+    }
+
+    /**
+     * @return the key associated with this Ref
+     */
+    public Key<T> key() {
+        return key;
+    }
+
+    /**
+     * Obtain the entity value associated with the key. Will pull from session if present, otherwise will
+     * fetch from the datastore.
+     *
+     * @return the entity referenced, or null if the entity was not found
+     */
+    abstract public T get();
+
+    /**
+     * If an entity has been loaded into the session or is otherwise available, this will return true.
+     * Calls to get() will not require a trip to backing store.
+     * Note that even when loaded, get() can still return null if there is no entity which corresponds to the key.
+     *
+     * @return true if the value is in the session or otherwise immediately available; false if get() will
+     * require a trip to the datastore or memcache.
+     */
+    abstract public boolean isLoaded();
+
+    /**
+     * This method exists to facilitate serialization via javabeans conventions. Unlike get(),
+     * it will return null if isLoaded() is false.
+     *
+     * @return the entity referenced, or null if either the entity was not found or isLoaded() is false.
+     */
+    final public T getValue() {
+        return isLoaded() ? get() : null;
+    }
+
+    /**
+     * Same as key() but conforms to JavaBeans conventions in case this is being processed by a JSON
+     * converter or expression language.
+     */
+    final public Key<T> getKey() {
+        return key();
+    }
+
+    /**
+     * Obtain the entity value, throwing an exception if the entity was not found.
+     *
+     * @return the entity referenced. Never returns null.
+     * @throws NotFoundException if the specified entity was not found
+     */
+    final public T safe() throws NotFoundException {
+        T t = this.get();
+        if (t == null)
+            throw new NotFoundException(key());
+        else
+            return t;
+    }
+
+    /** Comparison is based on key */
+    @Override
+    public int compareTo(Ref<T> o) {
+        return this.key().compareTo(o.key());
+    }
+
+    /** Equality comparison is based on key equivalence */
+    @Override
+    public boolean equals(Object obj) {
+        return obj != null && obj instanceof Ref && key().equals(((Ref<?>)obj).key());
+    }
+
+    /** Type-safe comparison for key equivalence */
+    public boolean equivalent(Ref<T> other) {
+        return equals(other);
+    }
+
+    /** Type safe comparison for key equivalence */
+    public boolean equivalent(Key<T> other) {
+        return key().equivalent(other);
+    }
+
+    /** Hash code is simply that of key */
+    @Override
+    public int hashCode() {
+        return key().hashCode();
+    }
+
+    /** Renders some info about the key */
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + "(" + key() + ")";
+    }
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/googlecode/objectify/impl/ref/DeadRef.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/googlecode/objectify/impl/ref/DeadRef.java
@@ -1,0 +1,54 @@
+package com.googlecode.objectify.impl.ref;
+
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.Ref;
+
+/**
+ * <p>Implementation of Ref which is disconnected from the live system; for example, this will be used
+ * if a Ref gets serialized or deserialized.</p>
+ *
+ * @author Jeff Schnitzer <jeff@infohazard.org>
+ */
+public class DeadRef<T> extends Ref<T> {
+
+    private static final long serialVersionUID = 1L;
+
+    /** */
+    T value;
+
+    /**
+     * For GWT serialization
+     */
+    protected DeadRef() {}
+
+    /**
+     * Create a Ref based on the key
+     */
+    public DeadRef( Key<T> key ) {
+        this( key, null );
+    }
+
+    /**
+     * Create a Ref based on the key and value
+     */
+    public DeadRef( Key<T> key, T value ) {
+        super( key );
+        this.value = value;
+    }
+
+    /* (non-Javadoc)
+     * @see com.googlecode.objectify.Ref#get()
+     */
+    @Override
+    public T get() {
+        return value;
+    }
+
+    /* (non-Javadoc)
+     * @see com.googlecode.objectify.Ref#isLoaded()
+     */
+    @Override
+    public boolean isLoaded() {
+        return true;
+    }
+}

--- a/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/googlecode/objectify/impl/ref/LiveRef.java
+++ b/extensions/objectify/src/main/resources/com/github/nmorel/gwtjackson/objectify/super/com/googlecode/objectify/impl/ref/LiveRef.java
@@ -1,0 +1,83 @@
+package com.googlecode.objectify.impl.ref;
+
+import java.io.ObjectStreamException;
+
+import com.google.gwt.core.shared.GwtIncompatible;
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.Objectify;
+import com.googlecode.objectify.ObjectifyService;
+import com.googlecode.objectify.Ref;
+
+/**
+ * <p>Implementation of Refs which are "live" and connected to the datastore so they can fetch
+ * entity values even if they have not already been loaded. This is the standard Ref implementation.</p>
+ *
+ * @author Jeff Schnitzer <jeff@infohazard.org>
+ */
+@GwtIncompatible
+public class LiveRef<T> extends Ref<T> {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * So that Refs can be associated with a session
+     */
+    protected transient Objectify ofy;
+
+    /**
+     * For GWT serialization
+     */
+    protected LiveRef() {}
+
+    /**
+     * Create a Ref based on the key
+     */
+    public LiveRef( Key<T> key ) {
+        this( key, ObjectifyService.ofy() );
+    }
+
+    /**
+     * Create a Ref based on the key, with the specified session
+     */
+    public LiveRef( Key<T> key, Objectify ofy ) {
+        super( key );
+        this.ofy = ofy;
+    }
+
+    /* (non-Javadoc)
+     * @see com.googlecode.objectify.Ref#get()
+     */
+    @Override
+    public T get() {
+        return ofy().load().now( key() );
+    }
+
+    /* (non-Javadoc)
+     * @see com.googlecode.objectify.Ref#isLoaded()
+     */
+    @Override
+    public boolean isLoaded() {
+        return ofy().isLoaded( key() );
+    }
+
+    /**
+     * Get the current objectify instance associated with this ref
+     */
+    private Objectify ofy() {
+        // If we have an expired transaction context, we need a new context
+        if ( ofy == null || (ofy.getTransaction() != null && !ofy.getTransaction().isActive()) ) {
+            ofy = ObjectifyService.ofy();
+        }
+
+        return ofy;
+    }
+
+    /**
+     * When this serializes, write out the DeadRef version. Use the getValue() for value so that
+     * if the value is not loaded, it serializes as null.
+     */
+    protected Object writeReplace() throws ObjectStreamException {
+        return new DeadRef<>( key(), getValue() );
+    }
+
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/BeanRefTestCase.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/BeanRefTestCase.java
@@ -1,0 +1,26 @@
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import com.github.nmorel.gwtjackson.client.ObjectMapper;
+import com.github.nmorel.gwtjackson.objectify.shared.BeanRefTester;
+import com.github.nmorel.gwtjackson.objectify.shared.ObjectifyAbstractTester.Bean;
+import com.google.gwt.core.client.GWT;
+import com.googlecode.objectify.Ref;
+import org.junit.Test;
+
+public class BeanRefTestCase extends GwtJacksonObjectifyTestCase {
+
+    @Test
+    public void test() throws Exception {
+        BeanRefTester.INSTANCE.testSerialize( createWriter( TestObjectMapper.INSTANCE ) );
+        BeanRefTester.INSTANCE.testDeserialize( createReader( TestObjectMapper.INSTANCE ) );
+
+        BeanRefTester.INSTANCE.testSerializeNonNull( createWriter( TestObjectMapper.INSTANCE, createNonNullContext() ) );
+        BeanRefTester.INSTANCE.testDeserializeNonNull( createReader( TestObjectMapper.INSTANCE ) );
+    }
+
+    public interface TestObjectMapper extends ObjectMapper<Ref<Bean>> {
+
+        TestObjectMapper INSTANCE = GWT.create( TestObjectMapper.class );
+    }
+
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/BeanTestCase.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/BeanTestCase.java
@@ -1,0 +1,24 @@
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import com.github.nmorel.gwtjackson.client.ObjectMapper;
+import com.github.nmorel.gwtjackson.objectify.shared.BeanTester;
+import com.github.nmorel.gwtjackson.objectify.shared.ObjectifyAbstractTester.Bean;
+import com.google.gwt.core.client.GWT;
+import org.junit.Test;
+
+public class BeanTestCase extends GwtJacksonObjectifyTestCase {
+
+    @Test
+    public void test() throws Exception {
+        BeanTester.INSTANCE.testSerialize( createWriter( TestObjectMapper.INSTANCE ) );
+        BeanTester.INSTANCE.testDeserialize( createReader( TestObjectMapper.INSTANCE ) );
+
+        BeanTester.INSTANCE.testSerializeNonNull( createWriter( TestObjectMapper.INSTANCE, createNonNullContext() ) );
+        BeanTester.INSTANCE.testDeserializeNonNull( createReader( TestObjectMapper.INSTANCE ) );
+    }
+
+    public interface TestObjectMapper extends ObjectMapper<Bean> {
+
+        TestObjectMapper INSTANCE = GWT.create( TestObjectMapper.class );
+    }
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/GwtJacksonObjectifyTestCase.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/GwtJacksonObjectifyTestCase.java
@@ -1,0 +1,16 @@
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import com.github.nmorel.gwtjackson.client.GwtJacksonTestCase;
+import com.github.nmorel.gwtjackson.client.JsonSerializationContext;
+
+public abstract class GwtJacksonObjectifyTestCase extends GwtJacksonTestCase {
+
+    @Override
+    public String getModuleName() {
+        return "com.github.nmorel.gwtjackson.objectify.GwtJacksonObjectifyTest";
+    }
+
+    protected JsonSerializationContext createNonNullContext() {
+        return JsonSerializationContext.builder().serializeNulls( false ).build();
+    }
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/GwtJacksonObjectifyTestSuite.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/GwtJacksonObjectifyTestSuite.java
@@ -1,0 +1,21 @@
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import com.google.gwt.junit.tools.GWTTestSuite;
+import junit.framework.Test;
+import junit.framework.TestCase;
+
+public class GwtJacksonObjectifyTestSuite extends TestCase {
+
+    public static Test suite() {
+        GWTTestSuite suite = new GWTTestSuite();
+        suite.addTestSuite( RawKeyTestCase.class );
+        suite.addTestSuite( RawKeyKeyTestCase.class );
+        suite.addTestSuite( KeyTestCase.class );
+        suite.addTestSuite( KeyKeyTestCase.class );
+        suite.addTestSuite( RefTestCase.class );
+        suite.addTestSuite( RefKeyTestCase.class );
+        suite.addTestSuite( BeanTestCase.class );
+        suite.addTestSuite( BeanRefTestCase.class );
+        return suite;
+    }
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/KeyKeyTestCase.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/KeyKeyTestCase.java
@@ -1,0 +1,26 @@
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import java.util.Map;
+
+import com.github.nmorel.gwtjackson.client.ObjectMapper;
+import com.github.nmorel.gwtjackson.objectify.shared.KeyKeyTester;
+import com.google.gwt.core.client.GWT;
+import com.googlecode.objectify.Key;
+import org.junit.Test;
+
+public class KeyKeyTestCase extends GwtJacksonObjectifyTestCase {
+
+    @Test
+    public void test() throws Exception {
+        KeyKeyTester.INSTANCE.testSerialize( createWriter( TestObjectMapper.INSTANCE ) );
+        KeyKeyTester.INSTANCE.testDeserialize( createReader( TestObjectMapper.INSTANCE ) );
+
+        KeyKeyTester.INSTANCE.testSerializeNonNull( createWriter( TestObjectMapper.INSTANCE, createNonNullContext() ) );
+        KeyKeyTester.INSTANCE.testDeserializeNonNull( createReader( TestObjectMapper.INSTANCE ) );
+    }
+
+    public interface TestObjectMapper extends ObjectMapper<Map<Key<Object>, Object>> {
+
+        TestObjectMapper INSTANCE = GWT.create( TestObjectMapper.class );
+    }
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/KeyTestCase.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/KeyTestCase.java
@@ -1,0 +1,24 @@
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import com.github.nmorel.gwtjackson.client.ObjectMapper;
+import com.github.nmorel.gwtjackson.objectify.shared.KeyTester;
+import com.google.gwt.core.client.GWT;
+import com.googlecode.objectify.Key;
+import org.junit.Test;
+
+public class KeyTestCase extends GwtJacksonObjectifyTestCase {
+
+    @Test
+    public void test() throws Exception {
+        KeyTester.INSTANCE.testSerialize( createWriter( TestObjectMapper.INSTANCE ) );
+        KeyTester.INSTANCE.testDeserialize( createReader( TestObjectMapper.INSTANCE ) );
+
+        KeyTester.INSTANCE.testSerializeNonNull( createWriter( TestObjectMapper.INSTANCE, createNonNullContext() ) );
+        KeyTester.INSTANCE.testDeserializeNonNull( createReader( TestObjectMapper.INSTANCE ) );
+    }
+
+    public interface TestObjectMapper extends ObjectMapper<Key<Object>> {
+
+        TestObjectMapper INSTANCE = GWT.create( TestObjectMapper.class );
+    }
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/RawKeyKeyTestCase.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/RawKeyKeyTestCase.java
@@ -1,0 +1,26 @@
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import java.util.Map;
+
+import com.github.nmorel.gwtjackson.client.ObjectMapper;
+import com.github.nmorel.gwtjackson.objectify.shared.RawKeyKeyTester;
+import com.google.appengine.api.datastore.Key;
+import com.google.gwt.core.client.GWT;
+import org.junit.Test;
+
+public class RawKeyKeyTestCase extends GwtJacksonObjectifyTestCase {
+
+    @Test
+    public void test() throws Exception {
+        RawKeyKeyTester.INSTANCE.testSerialize( createWriter( TestObjectMapper.INSTANCE ) );
+        RawKeyKeyTester.INSTANCE.testDeserialize( createReader( TestObjectMapper.INSTANCE ) );
+
+        RawKeyKeyTester.INSTANCE.testSerializeNonNull( createWriter( TestObjectMapper.INSTANCE, createNonNullContext() ) );
+        RawKeyKeyTester.INSTANCE.testDeserializeNonNull( createReader( TestObjectMapper.INSTANCE ) );
+    }
+
+    public interface TestObjectMapper extends ObjectMapper<Map<Key, Object>> {
+
+        TestObjectMapper INSTANCE = GWT.create( TestObjectMapper.class );
+    }
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/RawKeyTestCase.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/RawKeyTestCase.java
@@ -1,0 +1,25 @@
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import com.github.nmorel.gwtjackson.client.ObjectMapper;
+import com.github.nmorel.gwtjackson.objectify.shared.RawKeyTester;
+import com.google.appengine.api.datastore.Key;
+import com.google.gwt.core.client.GWT;
+import org.junit.Test;
+
+public class RawKeyTestCase extends GwtJacksonObjectifyTestCase {
+
+    public interface TestObjectMapper extends ObjectMapper<Key> {
+
+        TestObjectMapper INSTANCE = GWT.create( TestObjectMapper.class );
+    }
+
+    @Test
+    public void test() throws Exception {
+        RawKeyTester.INSTANCE.testSerialize( createWriter( TestObjectMapper.INSTANCE ) );
+        RawKeyTester.INSTANCE.testDeserialize( createReader( TestObjectMapper.INSTANCE ) );
+
+        RawKeyTester.INSTANCE.testSerializeNonNull( createWriter( TestObjectMapper.INSTANCE, createNonNullContext() ) );
+        RawKeyTester.INSTANCE.testDeserializeNonNull( createReader( TestObjectMapper.INSTANCE ) );
+
+    }
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/RefKeyTestCase.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/RefKeyTestCase.java
@@ -1,0 +1,26 @@
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import java.util.Map;
+
+import com.github.nmorel.gwtjackson.client.ObjectMapper;
+import com.github.nmorel.gwtjackson.objectify.shared.RefKeyTester;
+import com.google.gwt.core.client.GWT;
+import com.googlecode.objectify.Ref;
+import org.junit.Test;
+
+public class RefKeyTestCase extends GwtJacksonObjectifyTestCase {
+
+    @Test
+    public void test() throws Exception {
+        RefKeyTester.INSTANCE.testSerialize( createWriter( TestObjectMapper.INSTANCE ) );
+        RefKeyTester.INSTANCE.testDeserialize( createReader( TestObjectMapper.INSTANCE ) );
+
+        RefKeyTester.INSTANCE.testSerializeNonNull( createWriter( TestObjectMapper.INSTANCE, createNonNullContext() ) );
+        RefKeyTester.INSTANCE.testDeserializeNonNull( createReader( TestObjectMapper.INSTANCE ) );
+    }
+
+    public interface TestObjectMapper extends ObjectMapper<Map<Ref<Object>, Object>> {
+
+        TestObjectMapper INSTANCE = GWT.create( TestObjectMapper.class );
+    }
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/RefTestCase.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/client/RefTestCase.java
@@ -1,0 +1,24 @@
+package com.github.nmorel.gwtjackson.objectify.client;
+
+import com.github.nmorel.gwtjackson.client.ObjectMapper;
+import com.github.nmorel.gwtjackson.objectify.shared.RefTester;
+import com.google.gwt.core.client.GWT;
+import com.googlecode.objectify.Ref;
+import org.junit.Test;
+
+public class RefTestCase extends GwtJacksonObjectifyTestCase {
+
+    @Test
+    public void test() throws Exception {
+        RefTester.INSTANCE.testSerialize( createWriter( TestObjectMapper.INSTANCE ) );
+        RefTester.INSTANCE.testDeserialize( createReader( TestObjectMapper.INSTANCE ) );
+
+        RefTester.INSTANCE.testSerializeNonNull( createWriter( TestObjectMapper.INSTANCE, createNonNullContext() ) );
+        RefTester.INSTANCE.testDeserializeNonNull( createReader( TestObjectMapper.INSTANCE ) );
+    }
+
+    public interface TestObjectMapper extends ObjectMapper<Ref<Object>> {
+
+        TestObjectMapper INSTANCE = GWT.create( TestObjectMapper.class );
+    }
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/server/ObjectifyJacksonModuleTest.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/server/ObjectifyJacksonModuleTest.java
@@ -1,0 +1,149 @@
+package com.github.nmorel.gwtjackson.objectify.server;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.github.nmorel.gwtjackson.jackson.AbstractJacksonTest;
+import com.github.nmorel.gwtjackson.objectify.shared.BeanRefTester;
+import com.github.nmorel.gwtjackson.objectify.shared.BeanTester;
+import com.github.nmorel.gwtjackson.objectify.shared.KeyKeyTester;
+import com.github.nmorel.gwtjackson.objectify.shared.KeyTester;
+import com.github.nmorel.gwtjackson.objectify.shared.ObjectifyAbstractTester;
+import com.github.nmorel.gwtjackson.objectify.shared.ObjectifyAbstractTester.Bean;
+import com.github.nmorel.gwtjackson.objectify.shared.RawKeyKeyTester;
+import com.github.nmorel.gwtjackson.objectify.shared.RawKeyTester;
+import com.github.nmorel.gwtjackson.objectify.shared.RefKeyTester;
+import com.github.nmorel.gwtjackson.objectify.shared.RefTester;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.ObjectifyService;
+import com.googlecode.objectify.Ref;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ObjectifyJacksonModuleTest extends AbstractJacksonTest {
+
+    private final LocalServiceTestHelper helper = new LocalServiceTestHelper( new LocalDatastoreServiceTestConfig() );
+
+    private Closeable closeable;
+
+    @Rule
+    public final ExpectedException expectedEx = ExpectedException.none();
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        helper.setUp();
+        closeable = ObjectifyService.begin();
+        ObjectifyService.register( Bean.class );
+        objectMapper.registerModule( new ObjectifyJacksonModule() );
+        ObjectifyService.ofy().save().entity( ObjectifyAbstractTester.BEAN ).now();
+    }
+
+    @Test
+    public void testRawKey() throws Exception {
+        RawKeyTester.INSTANCE.testSerialize( createWriter( com.google.appengine.api.datastore.Key.class ) );
+        RawKeyTester.INSTANCE.testDeserialize( createReader( com.google.appengine.api.datastore.Key.class ) );
+
+        objectMapper.setSerializationInclusion( Include.NON_NULL );
+        RawKeyTester.INSTANCE.testSerializeNonNull( createWriter( com.google.appengine.api.datastore.Key.class ) );
+        RawKeyTester.INSTANCE.testDeserializeNonNull( createReader( com.google.appengine.api.datastore.Key.class ) );
+    }
+
+    @Test
+    public void testKey() throws Exception {
+        TypeReference<Key<Object>> typeReference = new TypeReference<Key<Object>>() {};
+        KeyTester.INSTANCE.testSerialize( createWriter( typeReference ) );
+        KeyTester.INSTANCE.testDeserialize( createReader( typeReference ) );
+
+        objectMapper.setSerializationInclusion( Include.NON_NULL );
+        KeyTester.INSTANCE.testSerializeNonNull( createWriter( typeReference ) );
+        KeyTester.INSTANCE.testDeserializeNonNull( createReader( typeReference ) );
+    }
+
+    @Test
+    public void testRefException() throws Exception {
+        expectedEx.expect( JsonMappingException.class );
+        expectedEx.expectMessage( "No content to map due to end-of-input" );
+        objectMapper.readValue( "", Ref.class );
+    }
+
+    @Test
+    public void testRef() throws Exception {
+        TypeReference<Ref<Object>> typeReference = new TypeReference<Ref<Object>>() {};
+        RefTester.INSTANCE.testSerialize( createWriter( typeReference ) );
+        RefTester.INSTANCE.testDeserialize( createReader( typeReference ) );
+
+        objectMapper.setSerializationInclusion( Include.NON_NULL );
+        RefTester.INSTANCE.testSerializeNonNull( createWriter( typeReference ) );
+        RefTester.INSTANCE.testDeserializeNonNull( createReader( typeReference ) );
+    }
+
+    @Test
+    public void testBean() throws Exception {
+        BeanTester.INSTANCE.testSerialize( createWriter( Bean.class ) );
+        BeanTester.INSTANCE.testDeserialize( createReader( Bean.class ) );
+
+        objectMapper.setSerializationInclusion( Include.NON_NULL );
+        BeanTester.INSTANCE.testSerializeNonNull( createWriter( Bean.class ) );
+        BeanTester.INSTANCE.testDeserializeNonNull( createReader( Bean.class ) );
+    }
+
+    @Test
+    public void testBeanRef() throws Exception {
+        TypeReference<Ref<Bean>> typeReference = new TypeReference<Ref<Bean>>() {};
+        BeanRefTester.INSTANCE.testSerialize( createWriter( typeReference ) );
+        BeanRefTester.INSTANCE.testDeserialize( createReader( typeReference ) );
+
+        objectMapper.setSerializationInclusion( Include.NON_NULL );
+        BeanRefTester.INSTANCE.testSerializeNonNull( createWriter( typeReference ) );
+        BeanRefTester.INSTANCE.testDeserializeNonNull( createReader( typeReference ) );
+    }
+
+    @Test
+    public void testRawKeyKey() throws Exception {
+        TypeReference<Map<com.google.appengine.api.datastore.Key, Object>> typeReference = new TypeReference<Map<com.google.appengine.api
+                .datastore.Key, Object>>() {};
+        RawKeyKeyTester.INSTANCE.testSerialize( createWriter( typeReference ) );
+        RawKeyKeyTester.INSTANCE.testDeserialize( createReader( typeReference ) );
+
+        objectMapper.setSerializationInclusion( Include.NON_NULL );
+        RawKeyKeyTester.INSTANCE.testSerializeNonNull( createWriter( typeReference ) );
+        RawKeyKeyTester.INSTANCE.testDeserializeNonNull( createReader( typeReference ) );
+    }
+
+    @Test
+    public void testKeyKey() throws Exception {
+        TypeReference<Map<Key<Object>, Object>> typeReference = new TypeReference<Map<Key<Object>, Object>>() {};
+        KeyKeyTester.INSTANCE.testSerialize( createWriter( typeReference ) );
+        KeyKeyTester.INSTANCE.testDeserialize( createReader( typeReference ) );
+
+        objectMapper.setSerializationInclusion( Include.NON_NULL );
+        KeyKeyTester.INSTANCE.testSerializeNonNull( createWriter( typeReference ) );
+        KeyKeyTester.INSTANCE.testDeserializeNonNull( createReader( typeReference ) );
+    }
+
+    @Test
+    public void testRefKey() throws Exception {
+        TypeReference<Map<Ref<Object>, Object>> typeReference = new TypeReference<Map<Ref<Object>, Object>>() {};
+        RefKeyTester.INSTANCE.testSerialize( createWriter( typeReference ) );
+        RefKeyTester.INSTANCE.testDeserialize( createReader( typeReference ) );
+
+        objectMapper.setSerializationInclusion( Include.NON_NULL );
+        RefKeyTester.INSTANCE.testSerializeNonNull( createWriter( typeReference ) );
+        RefKeyTester.INSTANCE.testDeserializeNonNull( createReader( typeReference ) );
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        closeable.close();
+        helper.tearDown();
+    }
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/shared/BeanRefTester.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/shared/BeanRefTester.java
@@ -1,0 +1,69 @@
+package com.github.nmorel.gwtjackson.objectify.shared;
+
+import com.github.nmorel.gwtjackson.shared.ObjectReaderTester;
+import com.github.nmorel.gwtjackson.shared.ObjectWriterTester;
+import com.googlecode.objectify.Ref;
+
+public final class BeanRefTester extends ObjectifyAbstractTester {
+
+    public static final BeanRefTester INSTANCE = new BeanRefTester();
+
+    private static final String BEAN_REF_JSON = "" +
+            "{" +
+            "\"key\":" +
+            "{\"raw\":" +
+            "{\"parent\":null," +
+            "\"kind\":\"Bean\"," +
+            "\"id\":1," +
+            "\"name\":null" +
+            "}" +
+            "}," +
+            "\"value\":" +
+            "{" +
+            "\"id\":1," +
+            "\"string\":\"string1\"," +
+            "\"set\":[1]" +
+            "}" +
+            "}";
+
+    private static final String BEAN_REF_NON_NULL_JSON = "" +
+            "{" +
+            "\"key\":" +
+            "{" +
+            "\"raw\":" +
+            "{" +
+            "\"kind\":\"Bean\"," +
+            "\"id\":1" +
+            "}" +
+            "}," +
+            "\"value\":" +
+            "{" +
+            "\"id\":1," +
+            "\"string\":\"string1\"," +
+            "\"set\":[1]" +
+            "}" +
+            "}";
+
+    private BeanRefTester() {
+    }
+
+    public void testSerialize( ObjectWriterTester<Ref<Bean>> writer ) {
+        assertEquals( BEAN_REF_JSON, writer.write( BEAN_REF ) );
+    }
+
+    public void testDeserialize( ObjectReaderTester<Ref<Bean>> reader ) {
+        Ref<Bean> result = reader.read( BEAN_REF_JSON );
+        assertEquals( BEAN_REF, result );
+        assertEquals( BEAN_REF.getValue(), result.getValue() );
+    }
+
+    public void testSerializeNonNull( ObjectWriterTester<Ref<Bean>> writer ) {
+        assertEquals( BEAN_REF_NON_NULL_JSON, writer.write( BEAN_REF ) );
+    }
+
+    public void testDeserializeNonNull( ObjectReaderTester<Ref<Bean>> reader ) {
+        Ref<Bean> result = reader.read( BEAN_REF_NON_NULL_JSON );
+        assertEquals( BEAN_REF, result );
+        assertEquals( BEAN_REF.getValue(), result.getValue() );
+    }
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/shared/BeanTester.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/shared/BeanTester.java
@@ -1,0 +1,37 @@
+package com.github.nmorel.gwtjackson.objectify.shared;
+
+import com.github.nmorel.gwtjackson.shared.ObjectReaderTester;
+import com.github.nmorel.gwtjackson.shared.ObjectWriterTester;
+
+public final class BeanTester extends ObjectifyAbstractTester {
+
+    public static final BeanTester INSTANCE = new BeanTester();
+
+    private static final String BEAN_JSON = "" +
+            "{" +
+            "\"id\":1," +
+            "\"string\":\"string1\"," +
+            "\"set\":[1]" +
+            "}";
+
+    private static final String BEAN_NON_NULL_JSON = BEAN_JSON;
+
+    private BeanTester() {
+    }
+
+    public void testSerialize( ObjectWriterTester<Bean> writer ) {
+        assertEquals( BEAN_JSON, writer.write( BEAN ) );
+    }
+
+    public void testDeserialize( ObjectReaderTester<Bean> reader ) {
+        assertEquals( BEAN, reader.read( BEAN_JSON ) );
+    }
+
+    public void testSerializeNonNull( ObjectWriterTester<Bean> writer ) {
+        assertEquals( BEAN_NON_NULL_JSON, writer.write( BEAN ) );
+    }
+
+    public void testDeserializeNonNull( ObjectReaderTester<Bean> reader ) {
+        assertEquals( BEAN, reader.read( BEAN_NON_NULL_JSON ) );
+    }
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/shared/KeyKeyTester.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/shared/KeyKeyTester.java
@@ -1,0 +1,55 @@
+package com.github.nmorel.gwtjackson.objectify.shared;
+
+import java.util.Map;
+
+import com.github.nmorel.gwtjackson.shared.ObjectReaderTester;
+import com.github.nmorel.gwtjackson.shared.ObjectWriterTester;
+import com.googlecode.objectify.Key;
+
+public final class KeyKeyTester extends ObjectifyAbstractTester {
+
+    public static final KeyKeyTester INSTANCE = new KeyKeyTester();
+
+    private static final String KEY_MAP1_JSON = "" +
+            "{" +
+            "\"{\\\"raw\\\":{\\\"parent\\\":null,\\\"kind\\\":\\\"Foo\\\",\\\"id\\\":1,\\\"name\\\":null}}\":null" +
+            "}";
+
+    private static final String KEY_MAP1_NON_NULL_JSON = "" +
+            "{" +
+            "\"{\\\"raw\\\":{\\\"kind\\\":\\\"Foo\\\",\\\"id\\\":1}}\":null" +
+            "}";
+
+    private static final String KEY_MAP2_JSON = "" +
+            "{\"{\\\"raw\\\":{\\\"parent\\\":{\\\"parent\\\":null,\\\"kind\\\":\\\"Foo\\\",\\\"id\\\":1,\\\"name\\\":null}," +
+            "\\\"kind\\\":\\\"Foo\\\",\\\"id\\\":0,\\\"name\\\":\\\"foo\\\"}}\":\"value2\"" +
+            "}";
+
+    private static final String KEY_MAP2_NON_NULL_JSON = "" +
+            "{\"{\\\"raw\\\":{\\\"parent\\\":{\\\"kind\\\":\\\"Foo\\\",\\\"id\\\":1},\\\"kind\\\":\\\"Foo\\\",\\\"id\\\":0," +
+            "\\\"name\\\":\\\"foo\\\"}}\":\"value2\"" +
+            "}";
+
+    private KeyKeyTester() {
+    }
+
+    public void testSerialize( ObjectWriterTester<Map<Key<Object>, Object>> writer ) {
+        assertEquals( KEY_MAP1_JSON, writer.write( KEY_MAP1 ) );
+        assertEquals( KEY_MAP2_JSON, writer.write( KEY_MAP2 ) );
+    }
+
+    public void testDeserialize( ObjectReaderTester<Map<Key<Object>, Object>> reader ) {
+        assertEquals( KEY_MAP1, reader.read( KEY_MAP1_JSON ) );
+        assertEquals( KEY_MAP2, reader.read( KEY_MAP2_JSON ) );
+    }
+
+    public void testSerializeNonNull( ObjectWriterTester<Map<Key<Object>, Object>> writer ) {
+        assertEquals( KEY_MAP1_NON_NULL_JSON, writer.write( KEY_MAP1 ) );
+        assertEquals( KEY_MAP2_NON_NULL_JSON, writer.write( KEY_MAP2 ) );
+    }
+
+    public void testDeserializeNonNull( ObjectReaderTester<Map<Key<Object>, Object>> reader ) {
+        assertEquals( KEY_MAP1, reader.read( KEY_MAP1_NON_NULL_JSON ) );
+        assertEquals( KEY_MAP2, reader.read( KEY_MAP2_NON_NULL_JSON ) );
+    }
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/shared/KeyTester.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/shared/KeyTester.java
@@ -1,0 +1,80 @@
+package com.github.nmorel.gwtjackson.objectify.shared;
+
+import com.github.nmorel.gwtjackson.shared.ObjectReaderTester;
+import com.github.nmorel.gwtjackson.shared.ObjectWriterTester;
+import com.googlecode.objectify.Key;
+
+public final class KeyTester extends ObjectifyAbstractTester {
+
+    public static final KeyTester INSTANCE = new KeyTester();
+
+    private static final String KEY1_JSON = "" +
+            "{" +
+            "\"raw\":" +
+            "{" +
+            "\"parent\":null," +
+            "\"kind\":\"Foo\"," +
+            "\"id\":1,\"name\":null" +
+            "}" +
+            "}";
+
+    private static final String KEY1_NON_NULL_JSON = "" +
+            "{" +
+            "\"raw\":" +
+            "{" +
+            "\"kind\":\"Foo\"" +
+            ",\"id\":1" +
+            "}" +
+            "}";
+
+    private static final String KEY2_JSON = "" +
+            "{" +
+            "\"raw\":" +
+            "{" +
+            "\"parent\":" +
+            "{\"parent\":null," +
+            "\"kind\":\"Foo\"," +
+            "\"id\":1," +
+            "\"name\":null" +
+            "}," +
+            "\"kind\":\"Foo\"," +
+            "\"id\":0," +
+            "\"name\":\"foo\"}" +
+            "}";
+
+    private static final String KEY2_NON_NULL_JSON = "" +
+            "{" +
+            "\"raw\":" +
+            "{" +
+            "\"parent\":" +
+            "{\"kind\":\"Foo\"," +
+            "\"id\":1}," +
+            "\"kind\":\"Foo\"," +
+            "\"id\":0," +
+            "\"name\":\"foo\"" +
+            "}" +
+            "}";
+
+    private KeyTester() {
+    }
+
+    public void testSerialize( ObjectWriterTester<Key<Object>> writer ) {
+        assertEquals( KEY1_JSON, writer.write( KEY1 ) );
+        assertEquals( KEY2_JSON, writer.write( KEY2 ) );
+    }
+
+    public void testDeserialize( ObjectReaderTester<Key<Object>> reader ) {
+        assertEquals( KEY1, reader.read( KEY1_JSON ) );
+        assertEquals( KEY2, reader.read( KEY2_JSON ) );
+    }
+
+    public void testSerializeNonNull( ObjectWriterTester<Key<Object>> writer ) {
+        assertEquals( KEY1_NON_NULL_JSON, writer.write( KEY1 ) );
+        assertEquals( KEY2_NON_NULL_JSON, writer.write( KEY2 ) );
+    }
+
+    public void testDeserializeNonNull( ObjectReaderTester<Key<Object>> reader ) {
+        assertEquals( KEY1, reader.read( KEY1_NON_NULL_JSON ) );
+        assertEquals( KEY2, reader.read( KEY2_NON_NULL_JSON ) );
+    }
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/shared/ObjectifyAbstractTester.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/shared/ObjectifyAbstractTester.java
@@ -1,0 +1,107 @@
+package com.github.nmorel.gwtjackson.objectify.shared;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import com.github.nmorel.gwtjackson.shared.AbstractTester;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.Ref;
+import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Id;
+import com.googlecode.objectify.impl.ref.DeadRef;
+
+public abstract class ObjectifyAbstractTester extends AbstractTester {
+
+    public static final com.google.appengine.api.datastore.Key RAW_KEY1;
+
+    public static final com.google.appengine.api.datastore.Key RAW_KEY2;
+
+    public static final Key<Object> KEY1;
+
+    public static final Key<Object> KEY2;
+
+    public static final Ref<Object> REF1;
+
+    public static final Ref<Object> REF2;
+
+    public static final Bean BEAN = new Bean( 1L, "string1", Collections.singleton( 1 ) );
+
+    public static final Ref<Bean> BEAN_REF = new DeadRef<Bean>( Key.<Bean>create( KeyFactory.createKey( null, "Bean", 1L ) ), BEAN );
+
+    public static final Map<com.google.appengine.api.datastore.Key, Object> RAW_KEY_MAP1;
+
+    public static final Map<com.google.appengine.api.datastore.Key, Object> RAW_KEY_MAP2;
+
+    public static final Map<Key<Object>, Object> KEY_MAP1;
+
+    public static final Map<Key<Object>, Object> KEY_MAP2;
+
+    public static final Map<Ref<Object>, Object> REF_MAP1;
+
+    public static final Map<Ref<Object>, Object> REF_MAP2;
+
+    static {
+        RAW_KEY1 = KeyFactory.createKey( null, "Foo", 1L );
+        RAW_KEY2 = KeyFactory.createKey( RAW_KEY1, "Foo", "foo" );
+        KEY1 = Key.create( RAW_KEY1 );
+        KEY2 = Key.create( RAW_KEY2 );
+        REF1 = new DeadRef<Object>( KEY1 );
+        REF2 = new DeadRef<Object>( KEY2 );
+        RAW_KEY_MAP1 = Collections.singletonMap( RAW_KEY1, null );
+        RAW_KEY_MAP2 = Collections.singletonMap( RAW_KEY2, (Object) "value2" );
+        KEY_MAP1 = Collections.singletonMap( KEY1, null );
+        KEY_MAP2 = Collections.singletonMap( KEY2, (Object) "value2" );
+        REF_MAP1 = Collections.singletonMap( REF1, null );
+        REF_MAP2 = Collections.singletonMap( REF2, (Object) "value2" );
+    }
+
+    @Entity
+    public static class Bean {
+
+        @Id
+        public Long id;
+
+        public String string;
+
+        public Set<Integer> set;
+
+        public Bean() {
+        }
+
+        public Bean( Long id, String string, Set<Integer> set ) {
+            this.id = id;
+            this.string = string;
+            this.set = set;
+        }
+
+        @Override
+        public boolean equals( Object o ) {
+            if ( this == o ) {
+                return true;
+            }
+            if ( !(o instanceof Bean) ) {
+                return false;
+            }
+
+            Bean bean = (Bean) o;
+
+            if ( id != null ? !id.equals( bean.id ) : bean.id != null ) {
+                return false;
+            }
+            if ( string != null ? !string.equals( bean.string ) : bean.string != null ) {
+                return false;
+            }
+            return set != null ? set.equals( bean.set ) : bean.set == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = id != null ? id.hashCode() : 0;
+            result = 31 * result + (string != null ? string.hashCode() : 0);
+            result = 31 * result + (set != null ? set.hashCode() : 0);
+            return result;
+        }
+    }
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/shared/RawKeyKeyTester.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/shared/RawKeyKeyTester.java
@@ -1,0 +1,53 @@
+package com.github.nmorel.gwtjackson.objectify.shared;
+
+import java.util.Map;
+
+import com.github.nmorel.gwtjackson.shared.ObjectReaderTester;
+import com.github.nmorel.gwtjackson.shared.ObjectWriterTester;
+import com.google.appengine.api.datastore.Key;
+
+public final class RawKeyKeyTester extends ObjectifyAbstractTester {
+
+    public static final RawKeyKeyTester INSTANCE = new RawKeyKeyTester();
+
+    private static final String RAW_KEY_MAP1_JSON = "" +
+            "{\"{\\\"parent\\\":null,\\\"kind\\\":\\\"Foo\\\",\\\"id\\\":1,\\\"name\\\":null}\":null" +
+            "}";
+
+    private static final String RAW_KEY_MAP1_NON_NULL_JSON = "" +
+            "{\"{\\\"kind\\\":\\\"Foo\\\",\\\"id\\\":1}\":null" +
+            "}";
+
+    private static final String RAW_KEY_MAP2_JSON = "" +
+            "{\"{\\\"parent\\\":{\\\"parent\\\":null,\\\"kind\\\":\\\"Foo\\\",\\\"id\\\":1,\\\"name\\\":null},\\\"kind\\\":\\\"Foo\\\"," +
+            "\\\"id\\\":0,\\\"name\\\":\\\"foo\\\"}\":\"value2\"" +
+            "}";
+
+    private static final String RAW_KEY_MAP2_NON_NULL_JSON = "" +
+            "{\"{\\\"parent\\\":{\\\"kind\\\":\\\"Foo\\\",\\\"id\\\":1},\\\"kind\\\":\\\"Foo\\\",\\\"id\\\":0," +
+            "\\\"name\\\":\\\"foo\\\"}\":\"value2\"" +
+            "}";
+
+    private RawKeyKeyTester() {
+    }
+
+    public void testSerialize( ObjectWriterTester<Map<Key, Object>> writer ) {
+        assertEquals( RAW_KEY_MAP1_JSON, writer.write( RAW_KEY_MAP1 ) );
+        assertEquals( RAW_KEY_MAP2_JSON, writer.write( RAW_KEY_MAP2 ) );
+    }
+
+    public void testDeserialize( ObjectReaderTester<Map<Key, Object>> reader ) {
+        assertEquals( RAW_KEY_MAP1, reader.read( RAW_KEY_MAP1_JSON ) );
+        assertEquals( RAW_KEY_MAP2, reader.read( RAW_KEY_MAP2_JSON ) );
+    }
+
+    public void testSerializeNonNull( ObjectWriterTester<Map<Key, Object>> writer ) {
+        assertEquals( RAW_KEY_MAP1_NON_NULL_JSON, writer.write( RAW_KEY_MAP1 ) );
+        assertEquals( RAW_KEY_MAP2_NON_NULL_JSON, writer.write( RAW_KEY_MAP2 ) );
+    }
+
+    public void testDeserializeNonNull( ObjectReaderTester<Map<Key, Object>> reader ) {
+        assertEquals( RAW_KEY_MAP1, reader.read( RAW_KEY_MAP1_NON_NULL_JSON ) );
+        assertEquals( RAW_KEY_MAP2, reader.read( RAW_KEY_MAP2_NON_NULL_JSON ) );
+    }
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/shared/RawKeyTester.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/shared/RawKeyTester.java
@@ -1,0 +1,73 @@
+package com.github.nmorel.gwtjackson.objectify.shared;
+
+import com.github.nmorel.gwtjackson.shared.ObjectReaderTester;
+import com.github.nmorel.gwtjackson.shared.ObjectWriterTester;
+import com.google.appengine.api.datastore.Key;
+
+public final class RawKeyTester extends ObjectifyAbstractTester {
+
+    public static final RawKeyTester INSTANCE = new RawKeyTester();
+
+    private static final String RAW_KEY1_JSON = "" +
+            "{" +
+            "\"parent\":null," +
+            "\"kind\":\"Foo\"," +
+            "\"id\":1," +
+            "\"name\":null" +
+            "}";
+
+    private static final String RAW_KEY1_NON_NULL_JSON = "" +
+            "{" +
+            "\"kind\":\"Foo\"," +
+            "\"id\":1" +
+            "}";
+
+    private static final String RAW_KEY2_JSON = "" +
+            "{" +
+            "\"parent\":" +
+            "{" +
+            "\"parent\":null," +
+            "\"kind\":\"Foo\"," +
+            "\"id\":1," +
+            "\"name\":null" +
+            "}," +
+            "\"kind\":\"Foo\"," +
+            "\"id\":0," +
+            "\"name\":\"foo\"" +
+            "}";
+
+    private static final String RAW_KEY2_NON_NULL_JSON = "" +
+            "{" +
+            "\"parent\":" +
+            "{" +
+            "\"kind\":\"Foo\"," +
+            "\"id\":1" +
+            "}," +
+            "\"kind\":\"Foo\"," +
+            "\"id\":0," +
+            "\"name\":\"foo\"" +
+            "}";
+
+    private RawKeyTester() {
+    }
+
+    public void testSerialize( ObjectWriterTester<Key> writer ) {
+        assertEquals( RAW_KEY1_JSON, writer.write( RAW_KEY1 ) );
+        assertEquals( RAW_KEY2_JSON, writer.write( RAW_KEY2 ) );
+    }
+
+    public void testDeserialize( ObjectReaderTester<Key> reader ) {
+        assertEquals( RAW_KEY1, reader.read( RAW_KEY1_JSON ) );
+        assertEquals( RAW_KEY2, reader.read( RAW_KEY2_JSON ) );
+    }
+
+    public void testSerializeNonNull( ObjectWriterTester<Key> writer ) {
+        assertEquals( RAW_KEY1_NON_NULL_JSON, writer.write( RAW_KEY1 ) );
+        assertEquals( RAW_KEY2_NON_NULL_JSON, writer.write( RAW_KEY2 ) );
+    }
+
+    public void testDeserializeNonNull( ObjectReaderTester<Key> reader ) {
+        assertEquals( RAW_KEY1, reader.read( RAW_KEY1_NON_NULL_JSON ) );
+        assertEquals( RAW_KEY2, reader.read( RAW_KEY2_NON_NULL_JSON ) );
+    }
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/shared/RefKeyTester.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/shared/RefKeyTester.java
@@ -1,0 +1,59 @@
+package com.github.nmorel.gwtjackson.objectify.shared;
+
+import java.util.Map;
+
+import com.github.nmorel.gwtjackson.shared.ObjectReaderTester;
+import com.github.nmorel.gwtjackson.shared.ObjectWriterTester;
+import com.googlecode.objectify.Ref;
+
+public final class RefKeyTester extends ObjectifyAbstractTester {
+
+    public static final RefKeyTester INSTANCE = new RefKeyTester();
+
+    private static final String REF_MAP1_JSON = "" +
+            "{" +
+            "\"{\\\"key\\\":{\\\"raw\\\":{\\\"parent\\\":null,\\\"kind\\\":\\\"Foo\\\",\\\"id\\\":1,\\\"name\\\":null}}," +
+            "\\\"value\\\":null}\":null" +
+            "}";
+
+    private static final String REF_MAP1_NON_NULL_JSON = "" +
+            "{" +
+            "\"{\\\"key\\\":{\\\"raw\\\":{\\\"kind\\\":\\\"Foo\\\",\\\"id\\\":1}}}\":null" +
+            "}";
+
+    private static final String REF_MAP2_JSON = "" +
+            "{" +
+            "\"{\\\"key\\\":{\\\"raw\\\":{\\\"parent\\\":{\\\"parent\\\":null,\\\"kind\\\":\\\"Foo\\\",\\\"id\\\":1,\\\"name\\\":null}," +
+            "\\\"kind\\\":\\\"Foo\\\",\\\"id\\\":0,\\\"name\\\":\\\"foo\\\"}}," +
+            "\\\"value\\\":null}\":\"value2\"" +
+            "}";
+
+    private static final String REF_MAP2_NON_NULL_JSON = "" +
+            "{" +
+            "\"{\\\"key\\\":{\\\"raw\\\":{\\\"parent\\\":{\\\"kind\\\":\\\"Foo\\\",\\\"id\\\":1},\\\"kind\\\":\\\"Foo\\\",\\\"id\\\":0," +
+            "\\\"name\\\":\\\"foo\\\"}}}\":\"value2\"" +
+            "}";
+
+    private RefKeyTester() {
+    }
+
+    public void testSerialize( ObjectWriterTester<Map<Ref<Object>, Object>> writer ) {
+        assertEquals( REF_MAP1_JSON, writer.write( REF_MAP1 ) );
+        assertEquals( REF_MAP2_JSON, writer.write( REF_MAP2 ) );
+    }
+
+    public void testDeserialize( ObjectReaderTester<Map<Ref<Object>, Object>> reader ) {
+        assertEquals( REF_MAP1, reader.read( REF_MAP1_JSON ) );
+        assertEquals( REF_MAP2, reader.read( REF_MAP2_JSON ) );
+    }
+
+    public void testSerializeNonNull( ObjectWriterTester<Map<Ref<Object>, Object>> writer ) {
+        assertEquals( REF_MAP1_NON_NULL_JSON, writer.write( REF_MAP1 ) );
+        assertEquals( REF_MAP2_NON_NULL_JSON, writer.write( REF_MAP2 ) );
+    }
+
+    public void testDeserializeNonNull( ObjectReaderTester<Map<Ref<Object>, Object>> reader ) {
+        assertEquals( REF_MAP1, reader.read( REF_MAP1_NON_NULL_JSON ) );
+        assertEquals( REF_MAP2, reader.read( REF_MAP2_NON_NULL_JSON ) );
+    }
+}

--- a/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/shared/RefTester.java
+++ b/extensions/objectify/src/test/java/com/github/nmorel/gwtjackson/objectify/shared/RefTester.java
@@ -1,0 +1,103 @@
+package com.github.nmorel.gwtjackson.objectify.shared;
+
+import com.github.nmorel.gwtjackson.shared.ObjectReaderTester;
+import com.github.nmorel.gwtjackson.shared.ObjectWriterTester;
+import com.googlecode.objectify.Ref;
+import com.googlecode.objectify.impl.ref.DeadRef;
+
+public final class RefTester extends ObjectifyAbstractTester {
+
+    public static final RefTester INSTANCE = new RefTester();
+
+    private static final String REF1_JSON = "" +
+            "{" +
+            "\"key\":" +
+            "{" +
+            "\"raw\":" +
+            "{" +
+            "\"parent\":null," +
+            "\"kind\":\"Foo\"," +
+            "\"id\":1," +
+            "\"name\":null" +
+            "}" +
+            "}," +
+            "\"value\":null" +
+            "}";
+
+    private static final String REF1_NON_NULL_JSON = "" +
+            "{" +
+            "\"key\":" +
+            "{" +
+            "\"raw\":" +
+            "{" +
+            "\"kind\":\"Foo\"," +
+            "\"id\":1" +
+            "}" +
+            "}" +
+            "}";
+
+    private static final String REF2_JSON = "" +
+            "{" +
+            "\"key\":" +
+            "{\"raw\":" +
+            "{" +
+            "\"parent\":" +
+            "{\"parent\":null," +
+            "\"kind\":\"Foo\"," +
+            "\"id\":1," +
+            "\"name\":null" +
+            "}," +
+            "\"kind\":\"Foo\"," +
+            "\"id\":0," +
+            "\"name\":\"foo\"" +
+            "}" +
+            "}," +
+            "\"value\":null" +
+            "}";
+
+    private static final String REF2_NON_NULL_JSON = "" +
+            "{\"key\":" +
+            "{" +
+            "\"raw\":" +
+            "{" +
+            "\"parent\":" +
+            "{" +
+            "\"kind\":\"Foo\"," +
+            "\"id\":1}," +
+            "\"kind\":\"Foo\"," +
+            "\"id\":0," +
+            "\"name\":\"foo\"" +
+            "}" +
+            "}" +
+            "}";
+
+    private RefTester() {
+    }
+
+    public void testSerialize( ObjectWriterTester<Ref<Object>> writer ) {
+        assertEquals( REF1_JSON, writer.write( REF1 ) );
+        assertEquals( REF2_JSON, writer.write( REF2 ) );
+    }
+
+    public void testDeserialize( ObjectReaderTester<Ref<Object>> reader ) {
+        Ref<Object> result1 = reader.read( REF1_JSON );
+        assertEquals( REF1, result1 );
+        assertTrue( result1 instanceof DeadRef );
+        assertNull( result1.getValue() );
+
+        Ref<Object> result2 = reader.read( REF2_JSON );
+        assertEquals( REF2, result2 );
+        assertTrue( result2 instanceof DeadRef );
+        assertNull( result2.getValue() );
+    }
+
+    public void testSerializeNonNull( ObjectWriterTester<Ref<Object>> writer ) {
+        assertEquals( REF1_NON_NULL_JSON, writer.write( REF1 ) );
+        assertEquals( REF2_NON_NULL_JSON, writer.write( REF2 ) );
+    }
+
+    public void testDeserializeNonNull( ObjectReaderTester<Ref<Object>> reader ) {
+        assertEquals( REF1, reader.read( REF1_NON_NULL_JSON ) );
+        assertEquals( REF2, reader.read( REF2_NON_NULL_JSON ) );
+    }
+}

--- a/extensions/objectify/src/test/resources/com/github/nmorel/gwtjackson/objectify/GwtJacksonObjectifyTest.gwt.xml
+++ b/extensions/objectify/src/test/resources/com/github/nmorel/gwtjackson/objectify/GwtJacksonObjectifyTest.gwt.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<module>
+  <inherits name="com.github.nmorel.gwtjackson.GwtJacksonSharedTest" />
+  <inherits name="com.github.nmorel.gwtjackson.objectify.GwtJacksonObjectify" />
+
+  <source path="client" />
+  <source path="shared" />
+</module>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -32,6 +32,7 @@
   <modules>
     <module>guava</module>
     <module>objectify</module>
+    <module>remotelogging</module>
   </modules>
 
   <dependencies>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -15,7 +15,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>com.github.nmorel.gwtjackson</groupId>
     <artifactId>gwt-jackson-parent</artifactId>
@@ -30,6 +31,7 @@
 
   <modules>
     <module>guava</module>
+    <module>objectify</module>
   </modules>
 
   <dependencies>

--- a/extensions/remotelogging/README.md
+++ b/extensions/remotelogging/README.md
@@ -1,0 +1,17 @@
+gwt-jackson-remotelogging
+=====
+This extension contains serializer for Throwable.
+
+It allows you to support the equivalent of GWT RPC Remote Logging http://www.gwtproject.org/doc/latest/DevGuideLogging.html#Remote_Logging
+
+To use it add the library to your classpath (for maven, the artifactId is `gwt-jackson-remotelogging`):
+1. Client-side: add `<inherits name="com.github.nmorel.gwtjackson.remotelogging.GwtJacksonRemoteLogging" />` to your module descriptor XML file.
+2. Server-side: register the Jackson module `RemoteLoggingJacksonModule`
+
+Full working demo project: [gwt-storage-objectify](https://github.com/freddyboucher/gwt-storage-objectify)
+
+
+Copyright and license
+-------------
+
+Copyright 2013 Nicolas Morel under the [Apache 2.0 license](LICENSE).

--- a/extensions/remotelogging/pom.xml
+++ b/extensions/remotelogging/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Nicolas Morel
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>com.github.nmorel.gwtjackson</groupId>
+    <artifactId>gwt-jackson-extensions</artifactId>
+    <version>0.14.3-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>gwt-jackson-remotelogging</artifactId>
+
+  <name>gwt-jackson :: Extensions :: Remote Logging</name>
+  <description>Extension to support remote logging of Throwable</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/client/**/*TestCase.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>gwt-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>packaging</id>
+            <goals>
+              <goal>resources</goal>
+            </goals>
+            <configuration>
+              <modules>
+                <module>com.github.nmorel.gwtjackson.remotelogging.GwtJacksonRemoteLogging</module>
+              </modules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>test-dev-mode</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <module>com.github.nmorel.gwtjackson.remotelogging.GwtJacksonRemoteLoggingTestSuite</module>
+              <out>${project.build.directory}/gwt/test/dev</out>
+            </configuration>
+          </execution>
+          <execution>
+            <id>test-prod</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <module>com.github.nmorel.gwtjackson.remotelogging.GwtJacksonRemoteLoggingTestSuite</module>
+              <out>${project.build.directory}/gwt/test/prod</out>
+              <productionMode>true</productionMode>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/extensions/remotelogging/src/main/java/com/github/nmorel/gwtjackson/remotelogging/client/StackTraceElementJsonSerializer.java
+++ b/extensions/remotelogging/src/main/java/com/github/nmorel/gwtjackson/remotelogging/client/StackTraceElementJsonSerializer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.remotelogging.client;
+
+import com.github.nmorel.gwtjackson.client.JsonSerializationContext;
+import com.github.nmorel.gwtjackson.client.JsonSerializer;
+import com.github.nmorel.gwtjackson.client.JsonSerializerParameters;
+import com.github.nmorel.gwtjackson.client.stream.JsonWriter;
+
+public class StackTraceElementJsonSerializer extends JsonSerializer<StackTraceElement> {
+
+    private static final StackTraceElementJsonSerializer INSTANCE = new StackTraceElementJsonSerializer();
+
+    private static final String METHOD_NAME = "methodName";
+
+    private static final String FILE_NAME = "fileName";
+
+    private static final String LINE_NUMBER = "lineNumber";
+
+    private static final String CLASS_NAME = "className";
+
+    public static StackTraceElementJsonSerializer getInstance() {
+        return INSTANCE;
+    }
+
+    private StackTraceElementJsonSerializer() { }
+
+    @Override
+    protected void doSerialize( JsonWriter writer, StackTraceElement stackTraceElement, JsonSerializationContext ctx,
+                                JsonSerializerParameters params ) {
+        writer.beginObject();
+        if ( stackTraceElement.getMethodName() != null || ctx.isSerializeNulls() ) {
+            writer.name( METHOD_NAME );
+            writer.value( stackTraceElement.getMethodName() );
+        }
+        if ( stackTraceElement.getFileName() != null || ctx.isSerializeNulls() ) {
+            writer.name( FILE_NAME );
+            writer.value( stackTraceElement.getFileName() );
+        }
+        writer.name( LINE_NUMBER );
+        writer.value( stackTraceElement.getLineNumber() );
+        if ( stackTraceElement.getClassName() != null || ctx.isSerializeNulls() ) {
+            writer.name( CLASS_NAME );
+            writer.value( stackTraceElement.getClassName() );
+        }
+        writer.endObject();
+    }
+}

--- a/extensions/remotelogging/src/main/java/com/github/nmorel/gwtjackson/remotelogging/client/ThrowableJsonSerializer.java
+++ b/extensions/remotelogging/src/main/java/com/github/nmorel/gwtjackson/remotelogging/client/ThrowableJsonSerializer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.remotelogging.client;
+
+import com.github.nmorel.gwtjackson.client.JsonSerializationContext;
+import com.github.nmorel.gwtjackson.client.JsonSerializer;
+import com.github.nmorel.gwtjackson.client.JsonSerializerParameters;
+import com.github.nmorel.gwtjackson.client.stream.JsonWriter;
+
+public class ThrowableJsonSerializer extends JsonSerializer<Throwable> {
+
+    private static final ThrowableJsonSerializer INSTANCE = new ThrowableJsonSerializer();
+
+    private static final String JSON_TYPE_INFO = "@class";
+
+    private static final String CAUSE = "cause";
+
+    private static final String STACK_TRACE = "stackTrace";
+
+    private static final String MESSAGE = "message";
+
+    private static final String LOCALIZED_MESSAGE = "localizedMessage";
+
+    public static ThrowableJsonSerializer getInstance() {
+        return INSTANCE;
+    }
+
+    private ThrowableJsonSerializer() { }
+
+    @Override
+    protected void doSerialize( JsonWriter writer, Throwable throwable, JsonSerializationContext ctx, JsonSerializerParameters params ) {
+        writer.beginObject();
+        writer.name( JSON_TYPE_INFO );
+        writer.value( throwable.getClass().getName() );
+
+        writer.name( CAUSE );
+        if ( throwable.getCause() != null ) {
+            serialize( writer, throwable.getCause(), ctx, params );
+        } else {
+            writer.nullValue();
+        }
+
+        writer.name( STACK_TRACE );
+        writer.beginArray();
+        for ( StackTraceElement stackTraceElement : throwable.getStackTrace() ) {
+            StackTraceElementJsonSerializer.getInstance().doSerialize( writer, stackTraceElement, ctx, params );
+        }
+        writer.endArray();
+
+        writer.name( MESSAGE );
+        writer.value( throwable.getMessage() );
+
+        writer.name( LOCALIZED_MESSAGE );
+        writer.value( throwable.getLocalizedMessage() );
+
+        writer.endObject();
+    }
+}

--- a/extensions/remotelogging/src/main/java/com/github/nmorel/gwtjackson/remotelogging/rebind/RemoteLoggingConfiguration.java
+++ b/extensions/remotelogging/src/main/java/com/github/nmorel/gwtjackson/remotelogging/rebind/RemoteLoggingConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.remotelogging.rebind;
+
+import com.github.nmorel.gwtjackson.client.AbstractConfiguration;
+import com.github.nmorel.gwtjackson.remotelogging.client.StackTraceElementJsonSerializer;
+import com.github.nmorel.gwtjackson.remotelogging.client.ThrowableJsonSerializer;
+
+public class RemoteLoggingConfiguration extends AbstractConfiguration {
+
+    @Override
+    protected void configure() {
+        type( StackTraceElement.class ).serializer( StackTraceElementJsonSerializer.class );
+        type( Throwable.class ).serializer( ThrowableJsonSerializer.class );
+    }
+
+}

--- a/extensions/remotelogging/src/main/java/com/github/nmorel/gwtjackson/remotelogging/server/RemoteLoggingJacksonModule.java
+++ b/extensions/remotelogging/src/main/java/com/github/nmorel/gwtjackson/remotelogging/server/RemoteLoggingJacksonModule.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Nicolas Morel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.nmorel.gwtjackson.remotelogging.server;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class RemoteLoggingJacksonModule extends SimpleModule {
+
+    private static final long serialVersionUID = 1L;
+
+    public RemoteLoggingJacksonModule() {
+        super( "RemoteLogging", Version.unknownVersion() );
+    }
+
+    @Override
+    public void setupModule( SetupContext context ) {
+        super.setupModule( context );
+        context.setMixInAnnotations( Throwable.class, ThrowableMixIn.class );
+        context.setMixInAnnotations( StackTraceElement.class, StackTraceElementMixIn.class );
+    }
+
+    @JsonTypeInfo( use = JsonTypeInfo.Id.CLASS )
+    @JsonIgnoreProperties( "suppressed" )
+    public abstract static class ThrowableMixIn {}
+
+    @JsonIgnoreProperties( "nativeMethod" )
+    public abstract static class StackTraceElementMixIn {}
+}

--- a/extensions/remotelogging/src/main/resources/com/github/nmorel/gwtjackson/remotelogging/GwtJacksonRemoteLogging.gwt.xml
+++ b/extensions/remotelogging/src/main/resources/com/github/nmorel/gwtjackson/remotelogging/GwtJacksonRemoteLogging.gwt.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<module>
+  <inherits name="com.github.nmorel.gwtjackson.GwtJackson" />
+
+  <extend-configuration-property name="gwtjackson.configuration.extension"
+                                 value="com.github.nmorel.gwtjackson.remotelogging.rebind.RemoteLoggingConfiguration" />
+
+  <source path="client" />
+</module>

--- a/extensions/remotelogging/src/test/java/com/github/nmorel/gwtjackson/remotelogging/client/GwtJacksonRemoteLoggingTestSuite.java
+++ b/extensions/remotelogging/src/test/java/com/github/nmorel/gwtjackson/remotelogging/client/GwtJacksonRemoteLoggingTestSuite.java
@@ -1,0 +1,14 @@
+package com.github.nmorel.gwtjackson.remotelogging.client;
+
+import com.google.gwt.junit.tools.GWTTestSuite;
+import junit.framework.Test;
+import junit.framework.TestCase;
+
+public class GwtJacksonRemoteLoggingTestSuite extends TestCase {
+
+    public static Test suite() {
+        GWTTestSuite suite = new GWTTestSuite();
+        suite.addTestSuite( ThrowableTestCase.class );
+        return suite;
+    }
+}

--- a/extensions/remotelogging/src/test/java/com/github/nmorel/gwtjackson/remotelogging/client/ThrowableTestCase.java
+++ b/extensions/remotelogging/src/test/java/com/github/nmorel/gwtjackson/remotelogging/client/ThrowableTestCase.java
@@ -1,0 +1,36 @@
+package com.github.nmorel.gwtjackson.remotelogging.client;
+
+import java.io.IOException;
+
+import com.github.nmorel.gwtjackson.client.GwtJacksonTestCase;
+import com.github.nmorel.gwtjackson.client.JsonSerializationContext;
+import com.github.nmorel.gwtjackson.client.ObjectWriter;
+import com.github.nmorel.gwtjackson.remotelogging.shared.ThrowableTester;
+import com.google.gwt.core.client.GWT;
+import org.junit.Test;
+
+public class ThrowableTestCase extends GwtJacksonTestCase {
+
+    private ThrowableTester tester = ThrowableTester.INSTANCE;
+
+    @Override
+    public String getModuleName() {
+        return "com.github.nmorel.gwtjackson.remotelogging.GwtJacksonRemoteLoggingTest";
+    }
+
+    @Test
+    public void testThrowable() throws IOException {
+        tester.testSerialize( createWriter( ThrowableWriter.INSTANCE ) );
+
+        tester.testSerializeNonNull( createWriter( ThrowableWriter.INSTANCE, createNonNullContext() ) );
+    }
+
+    public interface ThrowableWriter extends ObjectWriter<Throwable> {
+
+        ThrowableWriter INSTANCE = GWT.create( ThrowableWriter.class );
+    }
+
+    private JsonSerializationContext createNonNullContext() {
+        return JsonSerializationContext.builder().serializeNulls( false ).build();
+    }
+}

--- a/extensions/remotelogging/src/test/java/com/github/nmorel/gwtjackson/remotelogging/server/RemoteLoggingJacksonModuleTest.java
+++ b/extensions/remotelogging/src/test/java/com/github/nmorel/gwtjackson/remotelogging/server/RemoteLoggingJacksonModuleTest.java
@@ -1,0 +1,28 @@
+package com.github.nmorel.gwtjackson.remotelogging.server;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.github.nmorel.gwtjackson.jackson.AbstractJacksonTest;
+import com.github.nmorel.gwtjackson.remotelogging.shared.ThrowableTester;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RemoteLoggingJacksonModuleTest extends AbstractJacksonTest {
+
+    @Before
+    public void setUp() {
+        super.setUp();
+        objectMapper.registerModule( new RemoteLoggingJacksonModule() );
+    }
+
+    @Test
+    public void testThrowable() throws IOException {
+        ThrowableTester.INSTANCE.testSerialize( createWriter( Throwable.class ) );
+        ThrowableTester.INSTANCE.testDeserialize( createReader( Throwable.class ) );
+
+        objectMapper.setSerializationInclusion( Include.NON_NULL );
+        ThrowableTester.INSTANCE.testSerializeNonNull( createWriter( Throwable.class ) );
+        ThrowableTester.INSTANCE.testDeserializeNonNull( createReader( Throwable.class ) );
+    }
+}

--- a/extensions/remotelogging/src/test/java/com/github/nmorel/gwtjackson/remotelogging/shared/ThrowableTester.java
+++ b/extensions/remotelogging/src/test/java/com/github/nmorel/gwtjackson/remotelogging/shared/ThrowableTester.java
@@ -1,0 +1,76 @@
+package com.github.nmorel.gwtjackson.remotelogging.shared;
+
+import com.github.nmorel.gwtjackson.shared.AbstractTester;
+import com.github.nmorel.gwtjackson.shared.ObjectReaderTester;
+import com.github.nmorel.gwtjackson.shared.ObjectWriterTester;
+
+public final class ThrowableTester extends AbstractTester {
+
+    public static final ThrowableTester INSTANCE = new ThrowableTester();
+
+    public static final String THROWABLE_JSON = "" +
+            "{" +
+            "\"@class\":\"java.lang.IllegalArgumentException\"," +
+            "\"cause\":" +
+            "{" +
+            "\"@class\":\"java.lang.NullPointerException\"," +
+            "\"cause\":null," +
+            "\"stackTrace\":[]," +
+            "\"message\":null," +
+            "\"localizedMessage\":null" +
+            "}," +
+            "\"stackTrace\":" +
+            "[" +
+            "{" +
+            "\"methodName\":\"method0\"," +
+            "\"fileName\":\"Class0.java\"," +
+            "\"lineNumber\":0," +
+            "\"className\":\"com.Class0\"" +
+            "}," +
+            "{" +
+            "\"methodName\":\"method1\"," +
+            "\"fileName\":\"Class1.java\"," +
+            "\"lineNumber\":1," +
+            "\"className\":\"com.Class1\"" +
+            "}" +
+            "]," +
+            "\"message\":\"Var cannot be null.\"," +
+            "\"localizedMessage\":\"Var cannot be null.\"" +
+            "}";
+
+    public static final String THROWABLE_NON_NULL_JSON = THROWABLE_JSON;
+
+    public static final IllegalArgumentException THROWABLE;
+
+    static {
+        NullPointerException cause = new NullPointerException();
+        cause.setStackTrace( new StackTraceElement[]{} );
+        THROWABLE = new IllegalArgumentException( "Var cannot be null.", cause );
+        StackTraceElement elt0 = new StackTraceElement( "com.Class0", "method0", "Class0.java", 0 );
+        StackTraceElement elt1 = new StackTraceElement( "com.Class1", "method1", "Class1.java", 1 );
+        THROWABLE.setStackTrace( new StackTraceElement[]{elt0, elt1} );
+    }
+
+    private ThrowableTester() {
+    }
+
+    public void testSerialize( ObjectWriterTester<Throwable> writer ) {
+        assertEquals( THROWABLE_JSON, writer.write( THROWABLE ) );
+    }
+
+    public void testDeserialize( ObjectReaderTester<Throwable> reader ) {
+        Throwable throwable = reader.read( THROWABLE_JSON );
+        assertTrue( throwable instanceof IllegalArgumentException );
+        assertEquals( "Var cannot be null.", throwable.getMessage() );
+    }
+
+    public void testSerializeNonNull( ObjectWriterTester<Throwable> writer ) {
+        assertEquals( THROWABLE_NON_NULL_JSON, writer.write( THROWABLE ) );
+    }
+
+    public void testDeserializeNonNull( ObjectReaderTester<Throwable> reader ) {
+        Throwable throwable = reader.read( THROWABLE_NON_NULL_JSON );
+        assertTrue( throwable instanceof IllegalArgumentException );
+        assertEquals( "Var cannot be null.", throwable.getMessage() );
+    }
+}

--- a/extensions/remotelogging/src/test/resources/com/github/nmorel/gwtjackson/remotelogging/GwtJacksonRemoteLoggingTest.gwt.xml
+++ b/extensions/remotelogging/src/test/resources/com/github/nmorel/gwtjackson/remotelogging/GwtJacksonRemoteLoggingTest.gwt.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<module>
+  <inherits name="com.github.nmorel.gwtjackson.GwtJacksonSharedTest" />
+  <inherits name="com.github.nmorel.gwtjackson.remotelogging.GwtJacksonRemoteLogging" />
+
+  <source path="client" />
+  <source path="shared" />
+</module>


### PR DESCRIPTION
This pull request introduces 2 new extensions:
- Objectify
- Remote Logging

## Objectify
This extension contains serializer and deserializer for [Objectify](https://github.com/objectify/objectify) types like **Ref** or **Key**.

To use it add the library to your classpath (for maven, the artifactId is `gwt-jackson-objectify`):
1. Client-side: add `<inherits name="com.github.nmorel.gwtjackson.objectify.GwtJacksonObjectify" />` to your module descriptor XML file.
2. Server-side: register the Jackson module `ObjectifyJacksonModule`

Important note: **Ref\<T\>** is serialized as **DeadRef\<T\>** and the T value is serialized if it is loaded into the session.

## Remote Logging
This extension contains serializer for Throwable.

It allows you to support the equivalent of GWT RPC Remote Logging http://www.gwtproject.org/doc/latest/DevGuideLogging.html#Remote_Logging

To use it add the library to your classpath (for maven, the artifactId is `gwt-jackson-remotelogging`):
1. Client-side: add `<inherits name="com.github.nmorel.gwtjackson.remotelogging.GwtJacksonRemoteLogging" />` to your module descriptor XML file.
2. Server-side: register the Jackson module `RemoteLoggingJacksonModule`


Both extensions are used in the following demo project: [gwt-storage-objectify](https://github.com/freddyboucher/gwt-storage-objectify)