### PR TITLE
Upgraded jackson-version to 2.8.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,5 @@ sudo: false
 jdk:
   - oraclejdk8
   
-addons:
-  srcclr: true
 
 script: mvn clean install -Dgwt.compiler.skip=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,8 @@ sudo: false
 
 jdk:
   - oraclejdk8
+  
+addons:
+  srcclr: true
 
 script: mvn clean install -Dgwt.compiler.skip=true

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
 
     <!-- Dependencies version -->
     <gwt.version>2.7.0</gwt.version>
-    <jackson.version>2.8.4</jackson.version>
+    <jackson.version>2.8.10</jackson.version>
     <javapoet.version>1.0.0</javapoet.version>
     <junit.version>4.12</junit.version>
   </properties>


### PR DESCRIPTION
Jackson-databind is vulnerable to remote code execution (RCE) attacks. These attacks are possible during bean deserialization. Using this flaw attackers are able to execute code and commands.

For More info check out [this issue](https://github.com/FasterXML/jackson-databind/issues/1599)