### PR TITLE
Fix compilation issue due to incompatible classes

### DIFF
--- a/gwt-jackson/src/main/resources/com/fasterxml/jackson/annotation/JacksonAnnotation.gwt.xml
+++ b/gwt-jackson/src/main/resources/com/fasterxml/jackson/annotation/JacksonAnnotation.gwt.xml
@@ -16,8 +16,12 @@
   -->
 
 <module>
-  <source path="" />
+  <source path="">
+    <!--Only nested static class 'Value' should be excluded but syntax 'JacksonInject$Value.*' is not supported by GWT-->
+    <exclude name="JacksonInject.*" />
+    <exclude name="JsonSetter.*" />
+  </source>
   <!-- ObjectIdGenerators.Base implements Serializable but is not. We blacklist Jackson classes from RPC -->
   <inherits name="com.google.gwt.user.RemoteService" />
-  <extend-configuration-property name="rpc.blacklist" value="com.fasterxml.jackson.annotation.*"/>
+  <extend-configuration-property name="rpc.blacklist" value="com.fasterxml.jackson.annotation.*" />
 </module>


### PR DESCRIPTION
[INFO]    Tracing compile failure path for type 'com.fasterxml.jackson.annotation.JacksonInject'
[INFO]       [ERROR] Errors in 'jar:file:/Users/freddyboucher/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.9.5/jackson-annotations-2.9.5-sources.jar!/com/fasterxml/jackson/annotation/JacksonInject.java'
[INFO]          [ERROR] Line 166: The method format(String, Object, Boolean) is undefined for the type String
[INFO]    Tracing compile failure path for type 'com.fasterxml.jackson.annotation.JsonSetter'
[INFO]       [ERROR] Errors in 'jar:file:/Users/freddyboucher/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.9.5/jackson-annotations-2.9.5-sources.jar!/com/fasterxml/jackson/annotation/JsonSetter.java'
[INFO]          [ERROR] Line 246: The method format(String, Nulls, Nulls) is undefined for the type String
[INFO]    [ERROR] Aborting compile due to errors in some input files